### PR TITLE
Don't allow NativePin to have a 'reserved' pull-up

### DIFF
--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -359,7 +359,6 @@ class NativePin(LocalPiPin):
         'up':       0b10,
         'down':     0b01,
         'floating': 0b00,
-        'reserved': 0b11,
         }
 
     GPIO_FUNCTION_NAMES = {v: k for (k, v) in GPIO_FUNCTIONS.items()}


### PR DESCRIPTION
This prevents this (IMHO wrong) behaviour:
```python3
>>> from gpiozero import Device, Button
>>> from gpiozero.pins.native import NativeFactory
>>> Device.pin_factory = NativeFactory()
>>> b = Button(16)
>>> b.pin.pull
'up'
>>> b.pin.pull = 'reserved'
>>> b.pin.pull
'reserved'
```