### PR TITLE
Clearer error message for invalid bounce values

### DIFF
--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -315,8 +315,8 @@ class PiGPIOPin(PiPin):
     def _set_bounce(self, value):
         if value is None:
             value = 0
-        elif value < 0:
-            raise PinInvalidBounce('bounce must be 0 or greater')
+        elif not 0 <= value <= 0.3:
+            raise PinInvalidBounce('bounce must be between 0 and 0.3')
         self.factory.connection.set_glitch_filter(self.number, int(value * 1000000))
 
     def _get_edges(self):


### PR DESCRIPTION
The factory.connection.set_glitch_filter function from pigpio has a maximum steady parameter of [0.3 seconds.](https://abyz.me.uk/rpi/pigpio/pdif2.html#set_glitch_filter) Enforce that limit here to eliminate the more confusing "PI_BAD_FILTER" error from the pigpio library.