### PR TITLE
Embed pep-0008 / pep-0396 version number

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -144,3 +144,6 @@ from .internal_devices import (
     TimeOfDay,
     DiskUsage,
 )
+
+version_tuple = (1, 5, 1)
+version = version_string = __version__ = '%d.%d.%d' % version_tuple

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ elif sys.version_info[0] == 3:
 else:
     raise ValueError('Unrecognized major version of Python')
 
+import gpiozero
+
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Workaround <http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html>
@@ -24,7 +26,7 @@ except ImportError:
     pass
 
 __project__      = 'gpiozero'
-__version__      = '1.5.1'
+__version__      = gpiozero.__version__
 __author__       = 'Ben Nuttall'
 __author_email__ = 'ben@raspberrypi.org'
 __url__          = 'https://github.com/RPi-Distro/python-gpiozero'


### PR DESCRIPTION
Sample:

    Python 2.7.10 (default, May 23 2015, 09:40:32) [MSC v.1500 32 bit (Intel)] on win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import gpiozero
    >>> gpiozero.__version__
    u'1.5.1'
    >>> gpiozero.version
    u'1.5.1'