### PR TITLE
Add pulse_width setter to Servo class

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1486,13 +1486,13 @@ class Servo(SourceMixin, CompositeDevice):
         servo = Servo(17)
 
         servo.value = 0.5
-    
+
     .. note::
 
         To reduce servo jitter, use the pigpio pin driver rather than the default
         RPi.GPIO driver (pigpio uses DMA sampling for much more precise edge
         timing). See :ref:`changing-pin-factory` for further information.
-    
+
     :type pin: int or str
     :param pin:
         The GPIO pin that the servo is connected to. See :ref:`pin-numbering`
@@ -1541,13 +1541,13 @@ class Servo(SourceMixin, CompositeDevice):
             ),
             pin_factory=pin_factory
         )
-        
+
         if PiGPIOFactory is None or not isinstance(self.pin_factory, PiGPIOFactory):
             warnings.warn(PWMSoftwareFallback(
                 'To reduce servo jitter, use the pigpio pin factory.'
                 'See https://gpiozero.readthedocs.io/en/stable/api_output.html#servo for more info'
             ))
-        
+
         try:
             self.value = initial_value
         except:
@@ -1586,6 +1586,10 @@ class Servo(SourceMixin, CompositeDevice):
             return None
         else:
             return self.pwm_device.pin.state * self.frame_width
+
+    @pulse_width.setter
+    def pulse_width(self, value):
+        self.pwm_device.pin.state = value / self.frame_width
 
     def min(self):
         """


### PR DESCRIPTION
Partially fixes #795 - adds pulse_width setter to Servo class. Could we add a getter/setter to `PWMOutputDevice` too? It's not immediately obvious to me how.

@evildmp