### PR TITLE
Add Pibrella class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
     - "3.6"
     - "3.5"

--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,7 @@ Other contributors:
 - `Claire Pollard`_
 - `Philippe Muller`_
 - `Sofiia Kosovan`_
+- `Carl Monk`_
 
 
 .. _Andrew Scheller: https://github.com/lurch
@@ -178,3 +179,4 @@ Other contributors:
 .. _Claire Pollard: https://github.com/tuftii
 .. _Philippe Muller: https://github.com/pmuller
 .. _Sofiia Kosovan: https://github.com/SofiiaKosovan
+.. _Carl Monk: https://github.com/ForToffee

--- a/docs/api_boards.rst
+++ b/docs/api_boards.rst
@@ -154,6 +154,15 @@ JamHat
 
 .. autoclass:: JamHat(\*, pwm=False, pin_factory=None)
     :members:
+        :members:
+
+
+Pibrella
+--------
+
+.. autoclass:: Pibrella(\*, pwm=False, pin_factory=None)
+    :members:
+        :members:
 
 
 Robot

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ autodoc_member_order = 'groupwise'
 # -- Intersphinx configuration --------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3.7', None),
     'picamera': ('https://picamera.readthedocs.io/en/latest', None),
     'colorzero': ('https://colorzero.readthedocs.io/en/latest', None),
     }

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -2313,7 +2313,7 @@ class Pibrella(CompositeOutputDevice):
 
         .. attribute:: e, f, g, h
     """
-    def __init__(self, pwm=True, pin_factory=None):
+    def __init__(self, pwm=False, pin_factory=None):
         super(Pibrella, self).__init__(
             lights=TrafficLights(red=27, amber=17, green=4, pwm=pwm,
                               pin_factory=pin_factory),

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -2273,9 +2273,9 @@ class Pibrella(CompositeOutputDevice):
         btn.when_pressed = led.on
 
     :param bool pwm:
-        If :data:`True` (the default), construct :class:`PWMLED` instances to
-        represent each LED on the board. If :data:`False`, construct regular
-        :class:`LED` instances.
+        If :data:`True`, construct :class:`PWMLED` instances to represent each
+        LED on the board, otherwise if :data:`False` (the default), construct
+        regular :class:`LED` instances.
 
     :type pin_factory: Factory or None
     :param pin_factory:

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -2181,7 +2181,7 @@ class JamHat(CompositeOutputDevice):
         hat.off()
 
     :param bool pwm:
-        If :data:`True`, construct :class: PWMLED instances to represent each
+        If :data:`True`, construct :class:`PWMLED` instances to represent each
         LED on the board. If :data:`False` (the default), construct regular
         :class:`LED` instances.
 
@@ -2273,7 +2273,7 @@ class Pibrella(CompositeOutputDevice):
         btn.when_pressed = led.on
 
     :param bool pwm:
-        If :data:`True` (the default), construct :class: PWMLED instances to
+        If :data:`True` (the default), construct :class:`PWMLED` instances to
         represent each LED on the board. If :data:`False`, construct regular
         :class:`LED` instances.
 
@@ -2295,7 +2295,7 @@ class Pibrella(CompositeOutputDevice):
 
     .. attribute:: button
 
-        The red :class:`Button` objects on the Pibrella
+        The red :class:`Button` object on the Pibrella
 
     .. attribute:: buzzer
 
@@ -2303,13 +2303,13 @@ class Pibrella(CompositeOutputDevice):
 
     .. attribute:: inputs
 
-        A namedtuple of the input pin numbers
+        A :func:`~collections.namedtuple` of the input pin numbers
 
         .. attribute:: a, b, c, d
 
     .. attribute:: outputs
 
-        A namedtuple of the output pin numbers
+        A :func:`~collections.namedtuple` of the output pin numbers
 
         .. attribute:: e, f, g, h
     """

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -2319,7 +2319,7 @@ class Pibrella(CompositeOutputDevice):
                               pin_factory=pin_factory),
             button=Button(11, pull_up=False, pin_factory=pin_factory),
             buzzer=TonalBuzzer(18, pin_factory=pin_factory),
-            _order=('lights', 'buzzer', 'button'),
+            _order=('lights', 'button', 'buzzer'),
             pin_factory=pin_factory
         )
         InputPins = namedtuple('InputPins', ['a', 'b', 'c', 'd'])

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -194,7 +194,10 @@ class SPIWarning(GPIOZeroWarning):
 class SPISoftwareFallback(SPIWarning):
     "Warning raised when falling back to the SPI software implementation"
 
-class PWMSoftwareFallback(PinPWMError):
+class PWMWarning(GPIOZeroWarning):
+    "Base class for PWM warnings"
+
+class PWMSoftwareFallback(PWMWarning):
     "Warning raised when falling back to the PWM software implementation"
 
 class PinWarning(GPIOZeroWarning):

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1531,3 +1531,71 @@ def test_jamhat_pwm(mock_factory, pwm):
             False, False,           # buttons
             None                    # buzzer
         )
+
+def test_pibrella(mock_factory, pwm):
+    with Pibrella() as pb:
+        assert repr(pb).startswith('<gpiozero.Pibrella object')
+        assert isinstance(pb.lights, TrafficLights)
+        assert isinstance(pb.lights.red, LED)
+        assert isinstance(pb.button, Button)
+        assert isinstance(pb.buzzer, TonalBuzzer)
+        assert pb.inputs == (9, 7, 8, 10)
+        assert pb.outputs == (22, 23, 24, 25)
+        assert pb.value == (
+            (0, 0, 0),  # lights
+            0,          # button
+            None        # buzzer
+        )
+        pb.on()
+        assert pb.value == (
+            (1, 1, 1),  # lights
+            0,          # button
+            0           # buzzer
+        )
+        pb.buzzer.play('A5')
+        pb.button.pin.drive_high()
+        assert pb.value == (
+            (1, 1, 1),  # lights
+            1,          # button
+            1           # buzzer
+        )
+        pb.off()
+        assert pb.value == (
+            (0, 0, 0),  # lights
+            1,          # button
+            None        # buzzer
+        )
+
+def test_pibrella_pwm(mock_factory, pwm):
+    with Pibrella(pwm=True) as pb:
+        assert isinstance(pb.lights, TrafficLights)
+        assert isinstance(pb.lights.red, PWMLED)
+        assert isinstance(pb.button, Button)
+        assert isinstance(pb.buzzer, TonalBuzzer)
+        assert pb.inputs == (9, 7, 8, 10)
+        assert pb.outputs == (22, 23, 24, 25)
+        assert pb.value == (
+            (0, 0, 0),  # lights
+            0,          # button
+            None        # buzzer
+        )
+        pb.on()
+        assert pb.value == (
+            (1, 1, 1),  # lights
+            0,          # button
+            0           # buzzer
+        )
+        pb.off()
+        assert pb.value == (
+            (0, 0, 0),  # lights
+            0,          # button
+            None        # buzzer
+        )
+
+def test_pibrella_pins(mock_factory, pwm):
+    with Pibrella() as pb:
+        with LED(pb.outputs.e) as led:
+            assert isinstance(led, LED)
+            assert led.pin.number == 22
+        with Button(pb.inputs.a) as btn:
+            assert btn.pin.number == 9


### PR DESCRIPTION
Building on the excellent start made by @fortoffee in #773...

- lights is now a `TrafficLights` instance
- Removed `LEDBoard` & `ButtonBoard` instances
- Provided input and output pins as namedtuples of pins
- Provided example of using input and output pins

New example usage:

```python
from gpiozero import Pibrella

pb = Pibrella()

pb.button.wait_for_press()
pb.lights.on()
pb.buzzer.play('A4')
pb.off()
```

```python
from gpiozero import Pibrella, LED, Button

pb = Pibrella()
btn = Button(pb.inputs.a)
led = LED(pb.outputs.e)

btn.when_pressed = led.on
```

TODO:

- improve docstrings e.g. link namedtuple to python docs
- add tests