### PR TITLE
Warn users when falling back to NativeFactory, close #515

### DIFF
--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -69,7 +69,7 @@ from .compat import frozendict
 
 native_fallback_message = (
 'Falling back to the experimental pin factory NativeFactory because no other '
-'pin factory could be loaded. For best results, install RPi.GPIO or pigpio.'
+'pin factory could be loaded. For best results, install RPi.GPIO or pigpio. '
 'See https://gpiozero.readthedocs.io/en/stable/api_pins.html for more information.'
 )
 
@@ -281,7 +281,7 @@ class Device(ValuesMixin, GPIOBase):
                     module = __import__(mod_name, fromlist=(cls_name,))
                     pin_factory = getattr(module, cls_name)()
                     if name == 'native':
-                        warnings.warn(native_fallback_message, NativePinFactoryFallback)
+                        warnings.warn(NativePinFactoryFallback(native_fallback_message))
                     return pin_factory
                 except Exception as e:
                     warnings.warn(

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -279,9 +279,10 @@ class Device(ValuesMixin, GPIOBase):
                 try:
                     mod_name, cls_name = entry_point.split(':', 1)
                     module = __import__(mod_name, fromlist=(cls_name,))
+                    pin_factory = getattr(module, cls_name)()
                     if name == 'native':
                         warnings.warn(native_fallback_message, NativePinFactoryFallback)
-                    return getattr(module, cls_name)()
+                    return pin_factory
                 except Exception as e:
                     warnings.warn(
                         PinFactoryFallback(

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -62,9 +62,16 @@ from .exc import (
     GPIOPinMissing,
     GPIOPinInUse,
     GPIODeviceClosed,
+    NativePinFactoryFallback,
     PinFactoryFallback,
     )
 from .compat import frozendict
+
+native_fallback_message = (
+'Falling back to the experimental pin factory NativeFactory because no other '
+'pin factory could be loaded. For best results, install RPi.GPIO or pigpio.'
+'See https://gpiozero.readthedocs.io/en/stable/api_pins.html for more information.'
+)
 
 
 class GPIOMeta(type):
@@ -272,6 +279,8 @@ class Device(ValuesMixin, GPIOBase):
                 try:
                     mod_name, cls_name = entry_point.split(':', 1)
                     module = __import__(mod_name, fromlist=(cls_name,))
+                    if name == 'native':
+                        warnings.warn(native_fallback_message, NativePinFactoryFallback)
                     return getattr(module, cls_name)()
                 except Exception as e:
                     warnings.warn(

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -206,6 +206,9 @@ class PinWarning(GPIOZeroWarning):
 class PinFactoryFallback(PinWarning):
     "Warning raised when a default pin factory fails to load and a fallback is tried"
 
+class NativePinFactoryFallback(PinWarning):
+    "Warning raised when all other default pin factories fail to load and NativeFactory is used"
+
 class PinNonPhysical(PinWarning):
     "Warning raised when a non-physical pin is specified in a constructor"
 


### PR DESCRIPTION
Addresses #515 

Output:

```
(gpiozero) pi@raspberrypi:~ $ ipython
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from gpiozero import *                                                                       

In [2]: led = LED(2)                                                                                 
/home/pi/.virtualenvs/gpiozero/lib/python3.7/site-packages/gpiozero/devices.py:288: PinFactoryFallback: Falling back from rpigpio: No module named 'RPi'
  'Falling back from %s: %s' % (name, str(e))))
/home/pi/.virtualenvs/gpiozero/lib/python3.7/site-packages/gpiozero/devices.py:288: PinFactoryFallback: Falling back from rpio: No module named 'RPIO'
  'Falling back from %s: %s' % (name, str(e))))
/home/pi/.virtualenvs/gpiozero/lib/python3.7/site-packages/gpiozero/devices.py:288: PinFactoryFallback: Falling back from pigpio: No module named 'pigpio'
  'Falling back from %s: %s' % (name, str(e))))
/home/pi/.virtualenvs/gpiozero/lib/python3.7/site-packages/gpiozero/devices.py:283: NativePinFactoryFallback: Falling back to the experimental pin factory NativeFactory because no other pin factory could be loaded. For best results, install RPi.GPIO or pigpio.See https://gpiozero.readthedocs.io/en/stable/api_pins.html for more information.
  warnings.warn(native_fallback_message, NativePinFactoryFallback)

In [3]:  
```