### PR TITLE
Update migrating_from_rpigpio.rst

### DIFF
--- a/docs/migrating_from_rpigpio.rst
+++ b/docs/migrating_from_rpigpio.rst
@@ -304,8 +304,8 @@ In GPIO Zero::
 
     led = PWMLED(2)
 
-    for b in range(100):
-        led.value = b / 100
+    for b in range(101):
+        led.value = b / 100.0
         sleep(0.01)
 
 :class:`PWMLED` has a :meth:`~PWMLED.blink` method which can be used the same


### PR DESCRIPTION
The example for PWM migration should be led.value = b / 100.0 instead of led.value = b / 100 since range(100) yields integers and dividing by the literal int 100 will always result in 0.

It would also be best to change range(100) to range(101) to obtain the full range from 0.0 to 1.0 since the last step with range(100) would be 99/100.

Thank you for this great library!