### PR TITLE
callback after DigitalOutputDevice.blink ends

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -281,7 +281,7 @@ class DigitalOutputDevice(OutputDevice):
         """
         Make the device turn on and off according to a sequence list.
 
-        :type sequence: List[Tuple(bool, float)]
+        :type sequence: List[Tuple[bool, float]]
         :param sequence:
             list of value sets. Each value set consists of a value and a duration for this value.
 
@@ -609,7 +609,7 @@ class PWMOutputDevice(OutputDevice):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[PWMOutputDevice, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device
@@ -656,7 +656,7 @@ class PWMOutputDevice(OutputDevice):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[PWMOutputDevice, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device
@@ -670,7 +670,7 @@ class PWMOutputDevice(OutputDevice):
         """
         Make the device turn on and off according to a sequence list.
 
-        :type sequence: List[Tuple(float, float)]
+        :type sequence: List[Tuple[float, float]]
         :param sequence:
             list of value sets. Each value set consists of a value and a duration for this value.
 
@@ -689,7 +689,7 @@ class PWMOutputDevice(OutputDevice):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[PWMOutputDevice, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device
@@ -1268,7 +1268,7 @@ class RGBLED(SourceMixin, Device):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[RGBLED, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device
@@ -1325,7 +1325,7 @@ class RGBLED(SourceMixin, Device):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[RGBLED, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device
@@ -1374,7 +1374,7 @@ class RGBLED(SourceMixin, Device):
         """
         Make the device turn on and off according to a sequence list.
 
-        :type sequence: List[Tuple(bool, Union[~colorzero.Color,tuple])]
+        :type sequence: List[Tuple[bool, Union[~colorzero.Color, Tuple[float, float, float]]]]
         :param sequence:
             list of value sets. Each value set consists of a value and a duration for this value.
 
@@ -1393,7 +1393,7 @@ class RGBLED(SourceMixin, Device):
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
 
-        :type on_end: Callable[[DigitalOutputDevice, bool], None] or None
+        :type on_end: Callable[[RGBLED, bool], None] or None
         :param on_end:
             callback function to call after blink ended with parameters
                 self: the device

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -597,7 +597,7 @@ class PWMOutputDevice(OutputDevice):
             0.0 is fully off, 1.0 is fully on.
             Defaults to 0 (fully off).
 
-        :type end_value: int or None
+        :type end_value: float or None
         :param end_value:
             Duty cycle value to set after a full uninterrupted blink.
             Defaults to None (no value will be set).
@@ -692,7 +692,6 @@ class PWMOutputDevice(OutputDevice):
                 if self._blink_thread.stopping.wait(delay):
                     aborted = True
                     break
-
         if not aborted and end_value is not None:
             self._write(end_value)
         if on_end:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -238,7 +238,9 @@ class DigitalOutputDevice(OutputDevice):
         self._stop_blink()
         self._write(False)
 
-    def blink(self, on_time=1, off_time=1, end_state=None, n=None, background=True, on_end=None):
+    def blink(self,
+              on_time=1, off_time=1, end_state=None,
+              n=None, background=True, on_end=None):
         """
         Make the device turn on and off repeatedly.
 
@@ -583,13 +585,13 @@ class PWMOutputDevice(OutputDevice):
         :param float fps:
             sequence steps frequence for fading in Hz (steps per second)
 
-        :type on_value: int
+        :type on_value: float
         :param on_value:
             Duty cycle of the PWM device if on.
             0.0 is fully off, 1.0 is fully on.
             Defaults to 1 (fully on).
 
-        :type off_value: int
+        :type off_value: float
         :param off_value:
             Duty cycle of the PWM device if off.
             0.0 is fully off, 1.0 is fully on.
@@ -625,14 +627,14 @@ class PWMOutputDevice(OutputDevice):
                 percent = t / fade_in_time
                 sequence += (self.interpolate_value(percent, off_value, on_value), delta_t)
                 t += delta_t
-        sequence += (1, on_time)
+        sequence += (on_value, on_time)
         if fade_out_time > 0:
             t = delta_t
             while t <= fade_out_time:
                 percent = 1 - t / fade_out_time
                 sequence += (self.interpolate_value(percent, off_value, on_value), delta_t)
                 t += delta_t
-        sequence += (0, off_time)
+        sequence += (off_value, off_time)
         self.blink_sequence(sequence, end_value, n, on_end, background)
 
     def blink_sequence(self, sequence, end_value, n, on_end, background):
@@ -697,7 +699,7 @@ class PWMOutputDevice(OutputDevice):
             on_end(self, not aborted)
 
     def pulse(self, fade_in_time=1, fade_out_time=1, fps=25,
-              end_state=None,
+              on_value=1, off_value=0, end_value=None,
               n=None, background=True, on_end=None):
         """
         Make the device fade in and out repeatedly.
@@ -711,8 +713,18 @@ class PWMOutputDevice(OutputDevice):
         :param float fps:
             sequence steps frequence for fading in Hz (steps per second)
 
-        :type end_state: bool or None
-        :param end_state:
+        :param float on_value:
+            Duty cycle of the PWM device if on.
+            0.0 is fully off, 1.0 is fully on.
+            Defaults to 1 (fully on).
+
+        :param float off_value:
+            Duty cycle of the PWM device if off.
+            0.0 is fully off, 1.0 is fully on.
+            Defaults to 0 (fully off).
+
+        :type end_value: float or None
+        :param end_value:
             State to set after a full uninterrupted blink.
             Defaults to None, on which no state will be set.
 
@@ -734,7 +746,7 @@ class PWMOutputDevice(OutputDevice):
         """
         self.blink(
             on_time=0, off_time=0, fade_in_time=fade_in_time, fade_out_time=fade_out_time,
-            end_value=end_state, fps=fps,
+            fps=fps, on_value=on_value, off_value=off_value, end_value=end_value,
             n=n, background=background, on_end=on_end
         )
 

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -38,6 +38,9 @@ from __future__ import (
     absolute_import,
     division,
 )
+
+from time import time
+
 str = type('')
 
 from typing import *
@@ -323,12 +326,16 @@ class DigitalOutputDevice(OutputDevice):
 
     def _blink_device(self, sequence, n, end_state, on_end):
         def iterate_sequence():
+            t = time()
             iterable = repeat(0) if n is None else repeat(0, n)           
             for _ in iterable:
                 for value, duration in sequence:
                     self._write(value)
-                    if self._blink_thread.stopping.wait(duration):
-                        return True
+                    t += duration
+                    delay = t - time()
+                    if delay > 0:
+                        if self._blink_thread.stopping.wait(delay):
+                            return True
             return False
             
         stopped = iterate_sequence()
@@ -732,12 +739,16 @@ class PWMOutputDevice(OutputDevice):
 
     def _blink_device(self, sequence, n, end_value, on_end):
         def iterate_sequence():
+            t = time()
             iterable = repeat(0) if n is None else repeat(0, n)
             for _ in iterable:
                 for value, duration in sequence:
                     self._write(value)
-                    if self._blink_thread.stopping.wait(duration):
-                        return True
+                    t += duration
+                    delay = t - time()
+                    if delay > 0:
+                        if self._blink_thread.stopping.wait(delay):
+                            return True
             return False
 
         stopped = iterate_sequence()
@@ -1400,14 +1411,18 @@ class RGBLED(SourceMixin, Device):
 
     def _blink_sequence(self, sequence, n, end_color, on_end):
         def iterate_sequence():
+            t = time()
             red_pin, green_pin, blue_pin = self._leds
             iterable = repeat(0) if n is None else repeat(0, n)
             for _ in iterable:
                 for color, duration in sequence:
                     for led, value in zip(self._leds, color):
                         led._write(value)
-                    if self._blink_thread.stopping.wait(duration):
-                        return True
+                    t += duration
+                    delay = t - time()
+                    if delay > 0:
+                        if self._blink_thread.stopping.wait(duration):
+                            return True
             return False
 
         stopped = iterate_sequence()

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -43,7 +43,6 @@ from time import time
 
 str = type('')
 
-from typing import *
 from threading import Lock
 from itertools import repeat, cycle, chain
 from colorzero import Color

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -60,6 +60,7 @@ try:
 except ImportError:
     PiGPIOFactory = None
 
+
 class OutputDevice(SourceMixin, GPIODevice):
     """
     Represents a generic GPIO output device.
@@ -577,6 +578,9 @@ class PWMOutputDevice(OutputDevice):
         :param float fade_out_time:
             Number of seconds to spend fading out. Defaults to 0.
 
+        :param float fps:
+            sequence steps frequence for fading in Hz (steps per second)
+
         :type end_state: bool or None
         :param end_state:
             State to set after a full uninterrupted blink.
@@ -680,7 +684,7 @@ class PWMOutputDevice(OutputDevice):
         if on_end:
             on_end(self, not aborted)
 
-    def pulse(self, fade_in_time=0, fade_out_time=0, fps=25,
+    def pulse(self, fade_in_time=1, fade_out_time=1, fps=25,
               end_state=None,
               n=None, background=True, on_end=None):
         """
@@ -691,6 +695,9 @@ class PWMOutputDevice(OutputDevice):
 
         :param float fade_out_time:
             Number of seconds to spend fading out. Defaults to 1.
+
+        :param float fps:
+            sequence steps frequence for fading in Hz (steps per second)
 
         :type end_state: bool or None
         :param end_state:
@@ -1183,6 +1190,9 @@ class RGBLED(SourceMixin, Device):
             *pwm* was :data:`False` when the class was constructed
             (:exc:`ValueError` will be raised if not).
 
+        :param float fps:
+            sequence steps frequence for fading in Hz (steps per second)
+
         :type on_color: ~colorzero.Color or tuple
         :param on_color:
             The color to use when the LED is "on". Defaults to white.
@@ -1205,7 +1215,6 @@ class RGBLED(SourceMixin, Device):
             continue blinking and return immediately. If :data:`False`, only
             return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
-
 
         :type on_end: Callable[[RGBLED, bool], None] or None
         : param on_end:
@@ -1253,6 +1262,9 @@ class RGBLED(SourceMixin, Device):
         :param float fade_out_time:
             Number of seconds to spend fading out. Defaults to 1.
 
+        :param float fps:
+            sequence steps frequence for fading in Hz (steps per second)
+
         :type on_color: ~colorzero.Color or tuple
         :param on_color:
             The color to use when the LED is "on". Defaults to white.
@@ -1261,15 +1273,26 @@ class RGBLED(SourceMixin, Device):
         :param off_color:
             The color to use when the LED is "off". Defaults to black.
 
+        :type end_color: ~colorzero.Color or tuple or None
+        :param end_color:
+            color to set after a full uninterrupted blink.
+            Defaults to None, on which no color will be set.
+
         :type n: int or None
         :param n:
-            Number of times to pulse; :data:`None` (the default) means forever.
+            Number of times to blink; :data:`None` (the default) means forever.
 
         :param bool background:
             If :data:`True` (the default), start a background thread to
-            continue pulsing and return immediately. If :data:`False`, only
-            return when the pulse is finished (warning: the default value of
+            continue blinking and return immediately. If :data:`False`, only
+            return when the blink is finished (warning: the default value of
             *n* will result in this method never returning).
+
+        :type on_end: Callable[[RGBLED, bool], None] or None
+        : param on_end:
+            callback function to call after blink ended with parameters
+                self: the device
+                uninterrupted: True if the blinking sequence ended gracefully else False
         """
 
         self.blink(
@@ -1312,8 +1335,6 @@ class RGBLED(SourceMixin, Device):
             self._write(end_color)
         if on_end:
             on_end(self, not aborted)
-
-
 
 
 class Motor(SourceMixin, CompositeDevice):
@@ -1403,7 +1424,7 @@ class Motor(SourceMixin, CompositeDevice):
                 raise OutputDeviceBadValue(e)
         elif value < 0:
             try:
-               self.backward(-value)
+                self.backward(-value)
             except ValueError as e:
                 raise OutputDeviceBadValue(e)
         else:
@@ -1902,7 +1923,7 @@ class AngularServo(Servo):
         if initial_angle is None:
             initial_value = None
         elif ((min_angle <= initial_angle <= max_angle) or
-            (max_angle <= initial_angle <= min_angle)):
+              (max_angle <= initial_angle <= min_angle)):
             initial_value = 2 * ((initial_angle - min_angle) / self._angular_range) - 1
         else:
             raise OutputDeviceBadValue(

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -198,7 +198,7 @@ def test_output_blink_interrupt_on_end(mock_factory):
         device.blink(0.1, 1, on_end=on_end)
         sleep(0.2)
         device.off() # should interrupt
-        assert callback['called' ]
+        assert callback['called']
         assert callback['first_parameter'] == device
         assert callback['second_parameter'] == False
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -210,8 +210,7 @@ def test_output_blink_interrupt_end_state(mock_factory):
 def test_output_blink_end_state(mock_factory):
     pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
-        device.blink(0.1, 0.1, n=2, end_state=True)
-        sleep(0.5)
+        device.blink(0.1, 0.1, n=2, end_state=True, background=False)
         # blink sequence should have ended, end_state should be set
         assert len(pin.states) == 6
         assert pin.states[0].state == False   # initial         
@@ -250,13 +249,11 @@ def test_output_blink_interrupt_on_end(mock_factory):
         assert callback['second_parameter'] == True   
         pin.assert_states([False, True, False, True])
 
-
 def test_output_blink_sequence(mock_factory):
     pin = mock_factory.pin(4)
     with DigitalOutputDevice(4) as device:
-        sequence = []
-        device.blink(0.1, 0.1, n=2, end_state=True)
-        sleep(0.5)
+        sequence = [(True, 0.1), (False, 0.2), (True, 0.3), (False, 0.4)]
+        device.blink_sequence(sequence, n=2, end_state=True, background=False)
         # blink sequence should have ended, end_state should be set
         assert len(pin.states) == 6
         assert pin.states[0].state == False   # initial         


### PR DESCRIPTION
close #827

enhance blink method in DigitalOutputDevice, PWMOutputDevice and RGBLED:
- additional parameter on_end: callback function to call after blink ended
- additional parameter end_state / end_value / end_color: will be set, if a blink sequence was finished uninterrupted

new blink_sequence method in DigitalOutputDevice, PWMOutputDevice and RGBLED runs blinking sequences

additional feature: wait delay is time corrected, so that multiple independently blinking devices stay in sync

