### PR TITLE
remove print("here") from def all_values()

### DIFF
--- a/gpiozero/tools.py
+++ b/gpiozero/tools.py
@@ -322,7 +322,6 @@ def all_values(*values):
 
     .. _logical conjunction: https://en.wikipedia.org/wiki/Logical_conjunction
     """
-    print("here")
     values = [_normalize(v) for v in values]
     for v in zip(*values):
         yield all(v)


### PR DESCRIPTION
print ("here") is not needed 