### PR TITLE
Change average of MotionSensor to geometric mean instead of median

### DIFF
--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -45,7 +45,7 @@ import warnings
 from time import sleep, time
 from threading import Event, Lock
 try:
-    from statistics import median
+    from statistics import median, mean
 except ImportError:
     from .compat import median
 
@@ -614,7 +614,7 @@ class MotionSensor(SmoothedInputDevice):
         super(MotionSensor, self).__init__(
             pin, pull_up=pull_up, active_state=active_state,
             threshold=threshold, queue_len=queue_len, sample_wait=1 /
-            sample_rate, partial=partial, pin_factory=pin_factory)
+            sample_rate, partial=partial, pin_factory=pin_factory, average=mean)
         try:
             self._queue.start()
         except:


### PR DESCRIPTION
To make the `MotionSensor.threshold` configuration work, the average of the sensor values can't be the median, as the value is always either 0 or 1.
For example `[0,0,0,1,1]` is 0 and `[0,0,1,1,1]` is 1. Every threshold value larger than 0 will trigger as soon as the median is 1 and there is no granularity.
There are two potential fixes:
- change the average function of the internal queue from median to geometric mean
- remove the threshold configuration entirely and rely on the queue length

The first option, i.e. using the geometric mean to calculate the average is chosen in the PR to give more control to the user.