### PR TITLE
Energenie sockets preserve state

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -58,7 +58,6 @@ from .exc import (
     GPIOPinMissing,
     EnergenieSocketMissing,
     EnergenieBadSocket,
-    EnergenieBadInitialValue,
     OutputDeviceBadValue,
     CompositeDeviceBadDevice,
     )
@@ -2054,7 +2053,8 @@ class Energenie(SourceMixin, Device):
         means of reading their state, you may provide an initial state for
         the socket, which will be set upon construction. This defaults to
         :data:`False` which will switch the socket off.
-        Specifying :data:`None` will not switch the socket on construction.
+        Specifying :data:`None` will not set any initial state nor transmit any
+        control signal to the device.
 
     :type pin_factory: Factory or None
     :param pin_factory:
@@ -2068,15 +2068,13 @@ class Energenie(SourceMixin, Device):
             raise EnergenieSocketMissing('socket number must be provided')
         if not (1 <= socket <= 4):
             raise EnergenieBadSocket('socket number must be between 1 and 4')
-        if initial_value is None:
-            raise EnergenieBadInitialValue("initial value can't be None")
         self._value = None
         super(Energenie, self).__init__(pin_factory=pin_factory)
         self._socket = socket
         self._master = _EnergenieMaster(pin_factory=pin_factory)
         if initial_value:
             self.on()
-        elif initial_value == False:
+        elif initial_value is not None:
             self.off()
 
     def close(self):
@@ -2107,11 +2105,16 @@ class Energenie(SourceMixin, Device):
         """
         Returns :data:`True` if the socket is on and :data:`False` if the
         socket is off.  Setting this property changes the state of the socket.
+        Returns :data:`None` only when constructed with :data:`initial_value`
+        set to :data:`None` and neither :data:`on()` nor :data:`off()` have
+        been called since construction.
         """
         return self._value
 
     @value.setter
     def value(self, value):
+        if value is None:
+            raise TypeError('value cannot be None')
         value = bool(value)
         self._master.transmit(self._socket, value)
         self._value = value

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -2048,11 +2048,13 @@ class Energenie(SourceMixin, Device):
         Which socket this instance should control. This is an integer number
         between 1 and 4.
 
-    :param bool initial_value:
+    :type initial_value: bool or None
+    :param initial_value:
         The initial state of the socket. As Energenie sockets provide no
-        means of reading their state, you must provide an initial state for
+        means of reading their state, you may provide an initial state for
         the socket, which will be set upon construction. This defaults to
         :data:`False` which will switch the socket off.
+        Specifying :data:`None` will not switch the socket on construction.
 
     :type pin_factory: Factory or None
     :param pin_factory:
@@ -2074,7 +2076,7 @@ class Energenie(SourceMixin, Device):
         self._master = _EnergenieMaster(pin_factory=pin_factory)
         if initial_value:
             self.on()
-        else:
+        elif initial_value == False:
             self.off()
 
     def close(self):

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -78,9 +78,6 @@ class EnergenieSocketMissing(CompositeDeviceError, ValueError):
 class EnergenieBadSocket(CompositeDeviceError, ValueError):
     "Error raised when an invalid socket number is passed to :class:`Energenie`"
 
-class EnergenieBadInitialValue(CompositeDeviceError, ValueError):
-    "Error raised when an invalid initial value is passed to :class:`Energenie`"
-
 class SPIError(GPIOZeroError):
     "Base class for errors related to the SPI implementation"
 

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1264,19 +1264,21 @@ def test_energenie_bad_init(mock_factory):
         Energenie(0)
     with pytest.raises(ValueError):
         Energenie(5)
-    with pytest.raises(ValueError):
-        Energenie(1, initial_value=None)
 
 def test_energenie(mock_factory):
     pins = [mock_factory.pin(n) for n in (17, 22, 23, 27, 24, 25)]
     with Energenie(1, initial_value=True) as device1, \
-         Energenie(2, initial_value=False) as device2:
+         Energenie(2, initial_value=False) as device2, \
+         Energenie(3, initial_value=None) as device3:
         assert repr(device1) == '<gpiozero.Energenie object on socket 1>'
         assert repr(device2) == '<gpiozero.Energenie object on socket 2>'
+        assert repr(device3) == '<gpiozero.Energenie object on socket 3>'
         assert device1.value
         assert not device2.value
+        assert device3.value is None
         assert device1.socket == 1
         assert device2.socket == 2
+        assert device3.socket == 3
         [pin.clear_states() for pin in pins]
         device1.on()
         assert device1.value
@@ -1295,6 +1297,23 @@ def test_energenie(mock_factory):
         pins[3].assert_states_and_times([(0.0, True), (0.0, True)])
         pins[4].assert_states_and_times([(0.0, False)])
         pins[5].assert_states_and_times([(0.0, False), (0.1, True), (0.25, False)])
+        [pin.clear_states() for pin in pins]
+        device3.on()
+        assert device3.value
+        pins[0].assert_states_and_times([(0.0, False), (0.0, True)])
+        pins[1].assert_states_and_times([(0.0, True), (0.0, False)])
+        pins[2].assert_states_and_times([(0.0, True), (0.0, False)])
+        pins[3].assert_states_and_times([(0.0, True), (0.0, False)])
+        pins[4].assert_states_and_times([(0.0, False)])
+        pins[5].assert_states_and_times([(0.0, False), (0.1, True), (0.25, False)])
+
+        device3.value = False
+        assert not device3.value
+        device3.value = True
+        assert device3.value
+        with pytest.raises(TypeError):
+            device3.value = None
+
         device1.close()
         assert repr(device1) == '<gpiozero.Energenie object closed>'
 


### PR DESCRIPTION
At present when you initialise the `Energenie` class, sockets are either switched on or off according to `initial_value`.

Sometimes it is useful to initialise the class without setting a state, for example starting a service to control a socket which respects its initial state.

This PR allows specifying `None` as an `initial_value`, in which case no message is sent to the socket. 

The default behaviour of switching off the socket remains unchanged