### PR TITLE
Add missing Button import to led_button_remote_*.py examples

### DIFF
--- a/docs/examples/led_button_remote_1.py
+++ b/docs/examples/led_button_remote_1.py
@@ -1,4 +1,4 @@
-from gpiozero import LED
+from gpiozero import Button, LED
 from gpiozero.pins.pigpio import PiGPIOFactory
 from signal import pause
 

--- a/docs/examples/led_button_remote_2.py
+++ b/docs/examples/led_button_remote_2.py
@@ -1,4 +1,4 @@
-from gpiozero import LED
+from gpiozero import Button, LED
 from gpiozero.pins.pigpio import PiGPIOFactory
 from gpiozero.tools import all_values
 from signal import pause


### PR DESCRIPTION
`docs/examples/led_button_remote_1.py` and `docs/examples/led_button_remote_2.py` use `gpiozero.Button` but don't import it.