### PR TITLE
Make sure threads are brought down in all cases

### DIFF
--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -264,7 +264,7 @@ class DigitalOutputDevice(OutputDevice):
         )
         self._blink_thread.start()
         if not background:
-            self._blink_thread.join()
+            self._blink_thread.wait()
             self._blink_thread = None
 
     def _stop_blink(self):
@@ -536,7 +536,7 @@ class PWMOutputDevice(OutputDevice):
         )
         self._blink_thread.start()
         if not background:
-            self._blink_thread.join()
+            self._blink_thread.wait()
             self._blink_thread = None
 
     def pulse(self, fade_in_time=1, fade_out_time=1, n=None, background=True):
@@ -1089,7 +1089,7 @@ class RGBLED(SourceMixin, Device):
         )
         self._blink_thread.start()
         if not background:
-            self._blink_thread.join()
+            self._blink_thread.wait()
             self._blink_thread = None
 
     def pulse(

--- a/gpiozero/threads.py
+++ b/gpiozero/threads.py
@@ -71,7 +71,12 @@ class GPIOThread(Thread):
         self.stopping.set()
         self.join(timeout)
 
-    def join(self, timeout=None):
+    def wait(self):
+        self.join(stop=False)
+
+    def join(self, timeout=None, stop=True):
+        if stop and not self.stopping.is_set():
+            self.stopping.set()
         super(GPIOThread, self).join(timeout)
         if self.is_alive():
             assert timeout is not None

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -128,7 +128,7 @@ def test_output_blink_background(mock_factory):
         start = time()
         device.blink(0.1, 0.1, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        device._blink_thread.join() # naughty, but ensures no arbitrary waits in the test
+        device._blink_thread.wait() # naughty, but ensures no arbitrary waits in the test
         assert isclose(time() - start, 0.4, abs_tol=0.05)
         pin.assert_states_and_times([
             (0.0, False),
@@ -254,7 +254,7 @@ def test_output_pwm_blink_background(mock_factory, pwm):
         start = time()
         device.blink(0.1, 0.1, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        device._blink_thread.join()
+        device._blink_thread.wait()
         assert isclose(time() - start, 0.4, abs_tol=0.05)
         pin.assert_states_and_times([
             (0.0, 0),
@@ -288,7 +288,7 @@ def test_output_pwm_fade_background(mock_factory, pwm):
         start = time()
         device.blink(0, 0, 0.2, 0.2, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        device._blink_thread.join()
+        device._blink_thread.wait()
         assert isclose(time() - start, 0.8, abs_tol=0.05)
         pin.assert_states_and_times([
             (0.0, 0),
@@ -354,7 +354,7 @@ def test_output_pwm_pulse_background(mock_factory, pwm):
         start = time()
         device.pulse(0.2, 0.2, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        device._blink_thread.join()
+        device._blink_thread.wait()
         assert isclose(time() - start, 0.8, abs_tol=0.05)
         pin.assert_states_and_times([
             (0.0, 0),
@@ -706,7 +706,7 @@ def test_rgbled_blink_background(mock_factory, pwm):
         start = time()
         led.blink(0.1, 0.1, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        led._blink_thread.join()
+        led._blink_thread.wait()
         assert isclose(time() - start, 0.4, abs_tol=0.05)
         expected = [
             (0.0, 0),
@@ -727,7 +727,7 @@ def test_rgbled_blink_background_nonpwm(mock_factory):
         start = time()
         led.blink(0.1, 0.1, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        led._blink_thread.join()
+        led._blink_thread.wait()
         assert isclose(time() - start, 0.4, abs_tol=0.05)
         expected = [
             (0.0, 0),
@@ -786,7 +786,7 @@ def test_rgbled_fade_background(mock_factory, pwm):
         start = time()
         led.blink(0, 0, 0.2, 0.2, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        led._blink_thread.join()
+        led._blink_thread.wait()
         assert isclose(time() - start, 0.8, abs_tol=0.05)
         expected = [
             (0.0, 0),
@@ -872,7 +872,7 @@ def test_rgbled_pulse_background(mock_factory, pwm):
         start = time()
         led.pulse(0.2, 0.2, n=2)
         assert isclose(time() - start, 0, abs_tol=0.05)
-        led._blink_thread.join()
+        led._blink_thread.wait()
         assert isclose(time() - start, 0.8, abs_tol=0.05)
         expected = [
             (0.0, 0),


### PR DESCRIPTION
If shutting down all threads in a Python program by doing something like:
```
  idx = 0
  for thread in threading.enumerate():
      if idx != 0:
          thread.join(timeout=0.25)
      idx += 1
```
gpiozero will always throw the "Thread failed to die within X seconds" error.

Set the stop flag in join (if unset) to avoid this from happening.