### PR TITLE
Rotate option - to rotate pinout 180 degrees

### DIFF
--- a/gpiozero/pins/data.py
+++ b/gpiozero/pins/data.py
@@ -664,10 +664,13 @@ class HeaderInfo(namedtuple('HeaderInfo', (
     def _format_full(self, style):
         Cell = namedtuple('Cell', ('content', 'align', 'style'))
         lines = []
-        for row in sorted(range(self.rows), reverse=rotate):
+        for row in range(self.rows):
             line = []
-            for col in sorted(range(self.columns), reverse=rotate):
-                pin = (row * self.columns) + col + 1
+            for col in range(self.columns):
+                if rotate:
+                    pin = (((self.rows - 1) - row) * self.columns) + ((self.columns - 1) - col) + 1
+                else:
+                    pin = (row * self.columns) + col + 1
                 try:
                     pin = self.pins[pin]
                     cells = [

--- a/gpiozero/pins/data.py
+++ b/gpiozero/pins/data.py
@@ -47,6 +47,9 @@ from collections import namedtuple
 from ..exc import PinUnknownPi, PinMultiplePins, PinNoPins, PinInvalidPin
 from ..devices import Device
 
+# rotate pinout
+
+rotate = False
 
 # Some useful constants for describing pins
 
@@ -660,11 +663,10 @@ class HeaderInfo(namedtuple('HeaderInfo', (
 
     def _format_full(self, style):
         Cell = namedtuple('Cell', ('content', 'align', 'style'))
-
         lines = []
-        for row in range(self.rows):
+        for row in sorted(range(self.rows), reverse=rotate):
             line = []
-            for col in range(self.columns):
+            for col in sorted(range(self.columns), reverse=rotate):
                 pin = (row * self.columns) + col + 1
                 try:
                     pin = self.pins[pin]
@@ -1325,7 +1327,7 @@ class PiBoardInfo(namedtuple('PiBoardInfo', (
                 for header in sorted(self.headers.values(), key=attrgetter('name'))
                 )
 
-    def pprint(self, color=None):
+    def pprint(self, color=None, rotate=False):
         """
         Pretty-print a representation of the board along with header diagrams.
 
@@ -1334,6 +1336,7 @@ class PiBoardInfo(namedtuple('PiBoardInfo', (
         can be set to :data:`True` or :data:`False` to force color or monochrome
         output.
         """
+        globals()['rotate'] = rotate
         print('{0:{style} full}'.format(self, style=Style(color)))
 
 

--- a/gpiozerocli/pinout.py
+++ b/gpiozerocli/pinout.py
@@ -78,6 +78,13 @@ class PinoutTool(object):
             action='store_true',
             help='Open pinout.xyz in the default web browser'
         )
+        self.parser.add_argument(
+            '-t', '--transform',
+            dest='transform',
+            default=False,
+            action='store_true',
+            help='Transform pinout 180 degrees'
+        )
 
     def __call__(self, args=None):
         if args is None:
@@ -101,7 +108,7 @@ class PinoutTool(object):
         else:
             if args.revision == '':
                 try:
-                    pi_info().pprint(color=args.color)
+                    pi_info().pprint(color=args.color, rotate=args.transform)
                 except ImportError:
                     formatter = self.parser._get_formatter()
                     formatter.add_text(


### PR DESCRIPTION
I would be interested in improving this, by not using a global variable, the difficulty I found being that you can't add additional parameters to __format__ calls as far as I understand.

Example pinout:

```
J8:
   3V3  (1) (2)  5V    
 GPIO2  (3) (4)  5V    
 GPIO3  (5) (6)  GND   
 GPIO4  (7) (8)  GPIO14
   GND  (9) (10) GPIO15
GPIO17 (11) (12) GPIO18
GPIO27 (13) (14) GND   
GPIO22 (15) (16) GPIO23
   3V3 (17) (18) GPIO24
GPIO10 (19) (20) GND   
 GPIO9 (21) (22) GPIO25
GPIO11 (23) (24) GPIO8 
   GND (25) (26) GPIO7 
 GPIO0 (27) (28) GPIO1 
 GPIO5 (29) (30) GND   
 GPIO6 (31) (32) GPIO12
GPIO13 (33) (34) GND   
GPIO19 (35) (36) GPIO16
GPIO26 (37) (38) GPIO20
   GND (39) (40) GPIO21
```

Rotated pinout:
```
J8:
(40) GPIO21    GND (39)
(38) GPIO20 GPIO26 (37)
(36) GPIO16 GPIO19 (35)
(34) GND    GPIO13 (33)
(32) GPIO12  GPIO6 (31)
(30) GND     GPIO5 (29)
(28) GPIO1   GPIO0 (27)
(26) GPIO7     GND (25)
(24) GPIO8  GPIO11 (23)
(22) GPIO25  GPIO9 (21)
(20) GND    GPIO10 (19)
(18) GPIO24    3V3 (17)
(16) GPIO23 GPIO22 (15)
(14) GND    GPIO27 (13)
(12) GPIO18 GPIO17 (11)
(10) GPIO15    GND  (9)
(8)  GPIO14  GPIO4  (7)
(6)  GND     GPIO3  (5)
(4)  5V      GPIO2  (3)
(2)  5V        3V3  (1)
```