### PR TITLE
Independent mock factory instances

### DIFF
--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -40,7 +40,7 @@ str = type('')
 import os
 from collections import defaultdict, namedtuple
 from time import time, sleep
-from threading import Thread, Event
+from threading import Lock, Thread, Event
 try:
     from math import isclose
 except ImportError:
@@ -480,6 +480,7 @@ class MockFactory(LocalPiFactory):
 
         if independent:
             self._reservations = defaultdict(list)
+            self._res_lock = Lock()
             self.pins = {}
 
     def _get_revision(self):

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -38,7 +38,7 @@ str = type('')
 
 
 import os
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from time import time, sleep
 from threading import Thread, Event
 try:
@@ -461,7 +461,7 @@ class MockFactory(LocalPiFactory):
         construction to the value of the *pin_class* parameter in the
         constructor, or :class:`MockPin` if that is unspecified.
     """
-    def __init__(self, revision=None, pin_class=None):
+    def __init__(self, revision=None, pin_class=None, independent=False):
         super(MockFactory, self).__init__()
         if revision is None:
             revision = os.environ.get('GPIOZERO_MOCK_REVISION', 'a02082')
@@ -477,6 +477,10 @@ class MockFactory(LocalPiFactory):
         if not issubclass(pin_class, MockPin):
             raise ValueError('invalid mock pin_class: %r' % pin_class)
         self.pin_class = pin_class
+
+        if independent:
+            self._reservations = defaultdict(list)
+            self.pins = {}
 
     def _get_revision(self):
         return self._revision

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -41,7 +41,7 @@ from threading import Event
 
 import pytest
 
-from gpiozero.pins.mock import MockPWMPin, MockPin
+from gpiozero.pins.mock import MockFactory, MockPWMPin, MockPin
 from gpiozero import *
 
 
@@ -202,3 +202,14 @@ def test_mock_pin_edges(mock_factory):
     assert not fired.is_set()
     assert pin.edges == 'falling'
 
+def test_independent_mock_factories():
+    factory_a = MockFactory(independent=True)
+    factory_b = MockFactory(independent=True)
+
+    pin_number = 1
+    pin_1a = DigitalOutputDevice(pin_number, pin_factory=factory_a)
+    pin_1b = DigitalOutputDevice(pin_number, pin_factory=factory_b)
+
+    pin_1a.on()
+    assert pin_1a.value == 1
+    assert pin_1b.value == 0


### PR DESCRIPTION
Addresses #915 

This allows to create multiple completely independent `MockFactory` instances, creating independent pins as shown by the test.

I honestly feel like this is pretty hacky. Digging through the code I found that `LocalPiFactory` defines and uses class-wide variables: 

```python
class LocalPiFactory(PiFactory):
    # ...
    pins = {}
    _reservations = defaultdict(list)
    _res_lock = Lock()

    def __init__(self):
        # ...
        self.pins = LocalPiFactory.pins
        self._reservations = LocalPiFactory._reservations
        self._res_lock = LocalPiFactory._res_lock
```

So the newly introduced `independent` argument in the `MockFactory.__init__` pretty much just reverses the above back to the behavior of `PiFactory`.

Please, let me know if there's a better way!