### PR TITLE
Fix bugs related to PiGPIOSoftwareSPI cleanup

### DIFF
--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -495,7 +495,7 @@ class PiGPIOSoftwareSPI(SPI, Device):
             # If the factory has died already or we're not present in its
             # internal list, ignore the error
             pass
-        if not self.closed:
+        if not self._closed and self._factory.connection:
             self._closed = True
             self._factory.connection.bb_spi_close(self._select_pin)
         self._factory.release_all(self)

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -498,7 +498,7 @@ class PiGPIOSoftwareSPI(SPI, Device):
         if not self.closed:
             self._closed = True
             self._factory.connection.bb_spi_close(self._select_pin)
-        self.factory.release_all(self)
+        self._factory.release_all(self)
         super(PiGPIOSoftwareSPI, self).close()
 
     @property


### PR DESCRIPTION
I was initially encountering the following stack trace when using the pigpio pin factory.

```
<...>
File "/xxx/gpiozero/pins/pigpio.py", line 499, in close
    self.factory.release_all(self)
AttributeError: 'PiGPIOSoftwareSPI' object has no attribute 'factory'
```

I discovered this was due to a misnamed variable, which I addressed in the first commit. Afterward, I noticed the following stack trace.

```
<...>
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/xxx/gpiozero/devices.py", line 595, in _shutdown
    _devices_shutdown()
  File "/xxx/gpiozero/devices.py", line 588, in _devices_shutdown
    dev.close()
  File "/xxx/gpiozero/pins/pigpio.py", line 500, in close
    self._factory.connection.bb_spi_close(self._select_pin)
AttributeError: 'NoneType' object has no attribute 'bb_spi_close'
```

This was due to a combination of another misnamed variable and what seems to be a race condition where PiGPIOFactory object is closed before the software SPI object can close it. Both of these are addressed in the second commit.