### PR TITLE
Drop Python 3.2, 3.3 and 3.4 from testing, add 3.8 and 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,11 @@ __classifiers__ = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.2",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py32,py33,py34,py35,py36,py37}
+envlist = {py27,py35,py36,py37,py38,py39}
 
 [testenv]
 deps = .[test]
@@ -9,59 +9,4 @@ whitelist_externals = make
 setenv =
     COVERAGE_FILE=.coverage.{envname}
     GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
-passenv = GPIOZERO_* COVERAGE_*
-
-[testenv:py32]
-# All this shenanigans is to get tox (and everything else) working with python
-# 3.2. We stop venv for downloading or installing anything in the venv, because
-# all the local stuff almost certainly doesn't work on py3.2.
-basepython = python3.2
-setenv =
-    VIRTUALENV_NO_DOWNLOAD=1
-    VIRTUALENV_NO_PIP=1
-    VIRTUALENV_NO_WHEEL=1
-    VIRTUALENV_NO_SETUPTOOLS=1
-    COVERAGE_FILE=.coverage.{envname}
-    GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
-# The following lines are needed to stop tox trying to install dependencies (or
-# anything else) itself because pip won't exist in the venv yet.
-whitelist_externals =
-    echo
-    curl
-    pip
-    make
-deps =
-list_dependencies_command = echo
-skip_install = true
-# Now do everything manually...
-commands =
-    curl https://bootstrap.pypa.io/3.2/get-pip.py -o {envdir}/get-pip32.py
-    python {envdir}/get-pip32.py
-    pip install -e .[test]
-    make test
-passenv = GPIOZERO_* COVERAGE_*
-
-[testenv:py33]
-# Same story as above
-basepython = python3.3
-setenv =
-    VIRTUALENV_NO_DOWNLOAD=1
-    VIRTUALENV_NO_PIP=1
-    VIRTUALENV_NO_WHEEL=1
-    VIRTUALENV_NO_SETUPTOOLS=1
-    COVERAGE_FILE=.coverage.{envname}
-    GPIOZERO_TEST_LOCK={toxworkdir}/real_pins_lock
-whitelist_externals =
-    echo
-    curl
-    pip
-    make
-deps =
-list_dependencies_command = echo
-skip_install = true
-commands =
-    curl https://bootstrap.pypa.io/3.3/get-pip.py -o {envdir}/get-pip33.py
-    python {envdir}/get-pip33.py
-    pip install -e .[test]
-    make test
 passenv = GPIOZERO_* COVERAGE_*


### PR DESCRIPTION
Replaces #876 which did much the same for travis, which we've now moved away from.

We could drop 2.7 too...