### PR TITLE
Fix PiGPIO factory closing logic

### DIFF
--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -518,7 +518,7 @@ class PiGPIOSoftwareSPI(SPI):
             # If the factory has died already or we're not present in its
             # internal list, ignore the error
             pass
-        if not self.closed:
+        if not self._closed and self.pin_factory.connection:
             self._closed = True
             self.pin_factory.connection.bb_spi_close(self._select_pin)
         self.pin_factory.release_all(self)


### PR DESCRIPTION
I originally opened #920 but it was closed in favor of #929. However, the bug is still not fixed. I am receiving the following stack trace when the pigpio pin factory is cleaning up.

```
Traceback (most recent call last):
  File "/xxx/gpiozero/devices.py", line 619, in _shutdown
    _devices_shutdown()
  File "/xxx/gpiozero/devices.py", line 612, in _devices_shutdown
    dev.close()
  File "/xxx/gpiozero/pins/pigpio.py", line 523, in close
    self.pin_factory.connection.bb_spi_close(self._select_pin)
AttributeError: 'NoneType' object has no attribute 'bb_spi_close'
```

After this change the problem goes away.