### PR TITLE
Implement polling for internal devices

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -215,6 +215,9 @@ images/output_device_hierarchy.dot: $(PY_SOURCES)
 images/input_device_hierarchy.dot: $(PY_SOURCES)
 	./images/class_graph -i InputDevice -o EventsMixin -o HoldMixin > $@
 
+images/internal_device_hierarchy.dot: $(PY_SOURCES)
+	./images/class_graph -i InternalDevice -o EventsMixin > $@
+
 %.svg: %.mscgen
 	mscgen -T svg -o $@ $<
 

--- a/docs/api_internal.rst
+++ b/docs/api_internal.rst
@@ -88,8 +88,8 @@ attributes, so alternative methods using the other paradigms would also work.
 .. note::
     Note that although the constructor parameter ``pin_factory`` is available
     for internal devices, and is required to be valid, the pin factory chosen
-    will not make any difference. Reading a remote Pi's CPU temperature, for
-    example, is not currently possible.
+    will not make any practical difference. Reading a remote Pi's CPU
+    temperature, for example, is not currently possible.
 
 
 Regular Classes
@@ -102,35 +102,35 @@ named after. All classes in this section are concrete (not abstract).
 TimeOfDay
 ---------
 
-.. autoclass:: TimeOfDay(start_time, end_time, *, utc=True, pin_factory=None)
+.. autoclass:: TimeOfDay(start_time, end_time, *, utc=True, event_delay=10.0, pin_factory=None)
     :members: start_time, end_time, utc, value, is_active, when_activated, when_deactivated
 
 
 PingServer
 ----------
 
-.. autoclass:: PingServer(host, *, pin_factory=None)
+.. autoclass:: PingServer(host, *, event_delay=10.0, pin_factory=None)
     :members: host, value, is_active, when_activated, when_deactivated
 
 
 CPUTemperature
 --------------
 
-.. autoclass:: CPUTemperature(sensor_file='/sys/class/thermal/thermal_zone0/temp', *, min_temp=0.0, max_temp=100.0, threshold=80.0, pin_factory=None)
+.. autoclass:: CPUTemperature(sensor_file='/sys/class/thermal/thermal_zone0/temp', *, min_temp=0.0, max_temp=100.0, threshold=80.0, event_delay=5.0, pin_factory=None)
     :members: temperature, value, is_active, when_activated, when_deactivated
 
 
 LoadAverage
 -----------
 
-.. autoclass:: LoadAverage(load_average_file='/proc/loadavg', *, min_load_average=0.0, max_load_average=1.0, threshold=0.8, minutes=5, pin_factory=None)
+.. autoclass:: LoadAverage(load_average_file='/proc/loadavg', *, min_load_average=0.0, max_load_average=1.0, threshold=0.8, minutes=5, event_delay=10.0, pin_factory=None)
     :members: load_average, value, is_active, when_activated, when_deactivated
 
 
 DiskUsage
 ---------
 
-.. autoclass:: DiskUsage(filesystem='/', *, threshold=90.0, pin_factory=None)
+.. autoclass:: DiskUsage(filesystem='/', *, threshold=90.0, event_delay=30.0, pin_factory=None)
     :members: usage, value, is_active, when_activated, when_deactivated
 
 

--- a/docs/api_internal.rst
+++ b/docs/api_internal.rst
@@ -40,11 +40,56 @@ GPIO Zero also provides several "internal" devices which represent facilities
 provided by the operating system itself. These can be used to react to things
 like the time of day, or whether a server is available on the network.
 
-.. warning::
+These devices provide an API similar to and compatible with GPIO devices so that
+internal device events can trigger changes to GPIO output devices the way input
+devices can. In the same way a :class:`~gpiozero.Button` object is *active* when
+it's pressed, and can be used to trigger other devices when its state changes,
+a :class:`TimeOfDay` object is *active* during a particular time period.
 
-    These devices are experimental and their API is not yet considered stable.
-    We welcome any comments from testers, especially regarding new "internal
-    devices" that you'd find useful!
+Consider the following code in which a :class:`~gpiozero.Button` object is used
+to control an :class:`~gpiozero.LED` object::
+
+    from gpiozero import LED, Button
+    from signal import pause
+
+    led = LED(2)
+    btn = Button(3)
+
+    btn.when_pressed = led.on
+    btn.when_released = led.off
+
+    pause()
+
+Now consider the following example in which a :class:`TimeOfDay` object is used
+to control an :class:`~gpiozero.LED` using the same method::
+
+    from gpiozero import LED, TimeOfDay
+    from datetime import time
+    from signal import pause
+
+    led = LED(2)
+    tod = TimeOfDay(time(9), time(10))
+
+    tod.when_activated = led.on
+    tod.when_deactivated = led.off
+
+    pause()
+
+Here, rather than the LED being controlled by the press of a button, it's
+controlled by the time. When the time reaches 09:00AM, the LED comes on, and at
+10:00AM it goes off.
+
+Like the :class:`~gpiozero.Button` object, internal devices like the
+:class:`TimeOfDay` object has :attr:`~TimeOfDay.value`,
+:attr:`~TimeOfDay.values`, :attr:`~TimeOfDay.is_active`,
+:attr:`~TimeOfDay.when_activated` and :attr:`~TimeOfDay.when_deactivated`
+attributes, so alternative methods using the other paradigms would also work.
+
+.. note::
+    Note that although the constructor parameter ``pin_factory`` is available
+    for internal devices, and is required to be valid, the pin factory chosen
+    will not make any difference. Reading a remote Pi's CPU temperature, for
+    example, is not currently possible.
 
 
 Regular Classes
@@ -58,35 +103,35 @@ TimeOfDay
 ---------
 
 .. autoclass:: TimeOfDay(start_time, end_time, *, utc=True, pin_factory=None)
-    :members: start_time, end_time, utc, value
+    :members: start_time, end_time, utc, value, is_active, when_activated, when_deactivated
 
 
 PingServer
 ----------
 
 .. autoclass:: PingServer(host, *, pin_factory=None)
-    :members: host, value
+    :members: host, value, is_active, when_activated, when_deactivated
 
 
 CPUTemperature
 --------------
 
 .. autoclass:: CPUTemperature(sensor_file='/sys/class/thermal/thermal_zone0/temp', *, min_temp=0.0, max_temp=100.0, threshold=80.0, pin_factory=None)
-    :members: temperature, value, is_active
+    :members: temperature, value, is_active, when_activated, when_deactivated
 
 
 LoadAverage
 -----------
 
 .. autoclass:: LoadAverage(load_average_file='/proc/loadavg', *, min_load_average=0.0, max_load_average=1.0, threshold=0.8, minutes=5, pin_factory=None)
-    :members: load_average, value, is_active
+    :members: load_average, value, is_active, when_activated, when_deactivated
 
 
 DiskUsage
 ---------
 
 .. autoclass:: DiskUsage(filesystem='/', *, threshold=90.0, pin_factory=None)
-    :members: usage, value, is_active
+    :members: usage, value, is_active, when_activated, when_deactivated
 
 
 Base Classes
@@ -101,6 +146,12 @@ than concrete classes):
 
 The following sections document these base classes for advanced users that wish
 to construct classes for their own devices.
+
+
+PolledInternalDevice
+--------------------
+
+.. autoclass:: PolledInternalDevice(*, event_delay=1.0, pin_factory=None)
 
 
 InternalDevice

--- a/docs/examples/internet_status_indicator.py
+++ b/docs/examples/internet_status_indicator.py
@@ -7,8 +7,8 @@ red = LED(18)
 
 google = PingServer('google.com')
 
-green.source = google
-green.source_delay = 60
+google.when_activated = green.on
+google.when_deactivated = green.off
 red.source = negated(green)
 
 pause()

--- a/docs/examples/timed_heat_lamp.py
+++ b/docs/examples/timed_heat_lamp.py
@@ -5,7 +5,7 @@ from signal import pause
 lamp = Energenie(1)
 daytime = TimeOfDay(time(8), time(20))
 
-lamp.source = daytime
-lamp.source_delay = 60
+daytime.when_activated = lamp.on
+daytime.when_deactivated = lamp.off
 
 pause()

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -393,6 +393,61 @@ curve for beginners by making it easy to get started and easy to build up to
 more advanced projects.
 
 
+What's the difference between when_pressed, is_pressed and wait_for_press?
+==========================================================================
+
+gpiozero provides a range of different approaches to reading input devices.
+Sometimes you want to ask if a button's pressed, sometimes you want to do
+something until it's pressed, and sometimes you want something to happen *when*
+it's been pressed, regardless of what else is going on.
+
+In a simple example where the button is the only device in play, all of the
+options would be equally effective. But as soon as you introduce an extra
+element, like another GPIO device, you might need to choose the right approach
+depending on your use case.
+
+* :attr:`~gpiozero.Button.is_pressed` is an attribute which reveals whether the
+  button is currently pressed by returning ``True`` or ``False``::
+
+    while True:
+        if btn.is_pressed:
+            print("Pressed")
+        else:
+            print("Not pressed")
+
+* :meth:`~gpiozero.Button.wait_for_press()` as a method which blocks the code from
+  continuing until the button is pressed. Also see
+  :meth:`~gpiozero.Button.wait_for_release()`::
+
+    while True:
+        print("Released. Waiting for press..")
+        btn.wait_for_press()
+        print("Pressed. Waiting for release...")
+        btn.wait_for_release()
+
+* :attr:`~gpiozero.Button.when_pressed` is an attribute which assigns a callback
+  function to the event of the button being pressed. Every time the button is
+  pressed, the callback function is executed in a separate thread. Also see
+  :attr:`~gpiozero.Button.when_released`::
+
+    def pressed():
+        print("Pressed")
+
+    def released():
+        print("Released")
+
+    btn.when_pressed = pressed
+    btn.when_released = released
+
+This pattern of options is common among many devices. All :doc:`input devices
+<api_input>` and :doc:`internal devices <api_internal>` have ``is_active``,
+``when_activated``, ``when_deactivated``, ``wait_for_active`` and
+``wait_for_inactive``, and many provide aliases (such as "pressed" for
+"activated").
+
+Also see a more advanced approach in the :doc:`source_values` page.
+
+
 .. _get-pip: https://pip.pypa.io/en/stable/installing/
 .. _GitHub issues: https://github.com/gpiozero/gpiozero/issues
 .. _commits: https://github.com/gpiozero/gpiozero/commits/master

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -146,6 +146,7 @@ from .boards import (
 )
 from .internal_devices import (
     InternalDevice,
+    PolledInternalDevice,
     PingServer,
     CPUTemperature,
     LoadAverage,

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -68,6 +68,7 @@ from .mixins import (
     SourceMixin,
     ValuesMixin,
     EventsMixin,
+    event,
     HoldMixin,
 )
 from .input_devices import (

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -158,12 +158,13 @@ class GPIOBase(GPIOMeta(nstr('GPIOBase'), (), {})):
 
     def close(self):
         """
-        Shut down the device and release all associated resources. This method
-        can be called on an already closed device without raising an exception.
+        Shut down the device and release all associated resources (such as GPIO
+        pins).
 
-        This method is primarily intended for interactive use at the command
-        line. It disables the device and releases its pin(s) for use by another
-        device.
+        This method is idempotent (can be called on an already closed device
+        without any side-effects). It is primarily intended for interactive use
+        at the command line. It disables the device and releases its pin(s) for
+        use by another device.
 
         You can attempt to do this simply by deleting an object, but unless
         you've cleaned up all references to the object this may not work (even
@@ -196,8 +197,8 @@ class GPIOBase(GPIOMeta(nstr('GPIOBase'), (), {})):
         """
         # This is a placeholder which is simply here to ensure close() can be
         # safely called from subclasses without worrying whether super-classes
-        # have it (which in turn is useful in conjunction with the SourceMixin
-        # class).
+        # have it (which in turn is useful in conjunction with the mixin
+        # classes).
         pass
 
     @property

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -66,7 +66,7 @@ class PolledInternalDevice(InternalDevice):
     """
     Extends :class:`InternalDevice` to provide a background thread to poll
     internal devices that lack any other mechanism to inform the instance of
-    changes
+    changes.
     """
     def __init__(self, event_delay=1.0, pin_factory=None):
         self._event_thread = None
@@ -142,15 +142,19 @@ class PingServer(PolledInternalDevice):
     :param str host:
         The hostname or IP address to attempt to ping.
 
+    :type event_delay: float
+    :param event_delay:
+        The number of seconds between pings (defaults to 10 seconds).
+
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
-    def __init__(self, host, pin_factory=None):
+    def __init__(self, host, event_delay=10.0, pin_factory=None):
         self._host = host
         super(PingServer, self).__init__(
-            event_delay=10.0, pin_factory=pin_factory)
+            event_delay=event_delay, pin_factory=pin_factory)
         self._fire_events(self.pin_factory.ticks(), self.is_active)
 
     def __repr__(self):
@@ -254,16 +258,21 @@ class CPUTemperature(PolledInternalDevice):
         The temperature above which the device will be considered "active".
         (see :attr:`is_active`). This defaults to 80.0.
 
+    :type event_delay: float
+    :param event_delay:
+        The number of seconds between file reads (defaults to 5 seconds).
+
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
     def __init__(self, sensor_file='/sys/class/thermal/thermal_zone0/temp',
-            min_temp=0.0, max_temp=100.0, threshold=80.0, pin_factory=None):
+            min_temp=0.0, max_temp=100.0, threshold=80.0, event_delay=5.0,
+            pin_factory=None):
         self.sensor_file = sensor_file
         super(CPUTemperature, self).__init__(
-            event_delay=5.0, pin_factory=pin_factory)
+            event_delay=event_delay, pin_factory=pin_factory)
         if min_temp >= max_temp:
             raise ValueError('max_temp must be greater than min_temp')
         self.min_temp = min_temp
@@ -376,13 +385,18 @@ class LoadAverage(PolledInternalDevice):
         The number of minutes over which to average the load. Must be 1, 5 or
         15. This defaults to 5.
 
+    :type event_delay: float
+    :param event_delay:
+        The number of seconds between file reads (defaults to 10 seconds).
+
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
     def __init__(self, load_average_file='/proc/loadavg', min_load_average=0.0,
-        max_load_average=1.0, threshold=0.8, minutes=5, pin_factory=None):
+        max_load_average=1.0, threshold=0.8, minutes=5, event_delay=10.0,
+        pin_factory=None):
         if min_load_average >= max_load_average:
             raise ValueError(
                 'max_load_average must be greater than min_load_average')
@@ -402,7 +416,7 @@ class LoadAverage(PolledInternalDevice):
             15: 2,
         }[minutes]
         super(LoadAverage, self).__init__(
-            event_delay=10.0, pin_factory=pin_factory)
+            event_delay=event_delay, pin_factory=pin_factory)
         self._fire_events(self.pin_factory.ticks(), None)
 
     def __repr__(self):
@@ -502,17 +516,22 @@ class TimeOfDay(PolledInternalDevice):
         If :data:`True` (the default), a naive UTC time will be used for the
         comparison rather than a local time-zone reading.
 
+    :type event_delay: float
+    :param event_delay:
+        The number of seconds between file reads (defaults to 10 seconds).
+
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
-    def __init__(self, start_time, end_time, utc=True, pin_factory=None):
+    def __init__(self, start_time, end_time, utc=True, event_delay=5.0,
+                 pin_factory=None):
         self._start_time = None
         self._end_time = None
         self._utc = True
         super(TimeOfDay, self).__init__(
-            event_delay=5.0, pin_factory=pin_factory)
+            event_delay=event_delay, pin_factory=pin_factory)
         self._start_time = self._validate_time(start_time)
         self._end_time = self._validate_time(end_time)
         if self.start_time == self.end_time:
@@ -628,14 +647,19 @@ class DiskUsage(PolledInternalDevice):
         The disk usage percentage above which the device will be considered
         "active" (see :attr:`is_active`). This defaults to 90.0.
 
+    :type event_delay: float
+    :param event_delay:
+        The number of seconds between file reads (defaults to 30 seconds).
+
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
-    def __init__(self, filesystem='/', threshold=90.0, pin_factory=None):
+    def __init__(self, filesystem='/', threshold=90.0, event_delay=30.0,
+                 pin_factory=None):
         super(DiskUsage, self).__init__(
-            event_delay=30.0, pin_factory=pin_factory)
+            event_delay=event_delay, pin_factory=pin_factory)
         os.statvfs(filesystem)
         if not 0 <= threshold <= 100:
             warnings.warn(ThresholdOutOfRange(

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -92,6 +92,22 @@ class PolledInternalDevice(InternalDevice):
     def event_delay(self, value):
         self._event_delay = float(value)
 
+    def wait_for_active(self, timeout=None):
+        self._start_stop_events(True)
+        try:
+            return super(PolledInternalDevice, self).wait_for_active(timeout)
+        finally:
+            self._start_stop_events(
+                self.when_activated or self.when_deactivated)
+
+    def wait_for_inactive(self, timeout=None):
+        self._start_stop_events(True)
+        try:
+            return super(PolledInternalDevice, self).wait_for_inactive(timeout)
+        finally:
+            self._start_stop_events(
+                self.when_activated or self.when_deactivated)
+
     def _watch_value(self):
         while not self._event_thread.stopping.wait(self._event_delay):
             self._fire_events(self.pin_factory.ticks(), self.is_active)

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -288,7 +288,7 @@ class EventsMixin(object):
         This can be set to a function which accepts no (mandatory) parameters,
         or a Python function which accepts a single mandatory parameter (with
         as many optional parameters as you like). If the function accepts a
-        single mandatory parameter, the device that activated will be passed
+        single mandatory parameter, the device that activated it will be passed
         as that parameter.
 
         Set this property to :data:`None` (the default) to disable the event.
@@ -302,7 +302,7 @@ class EventsMixin(object):
         This can be set to a function which accepts no (mandatory) parameters,
         or a Python function which accepts a single mandatory parameter (with
         as many optional parameters as you like). If the function accepts a
-        single mandatory parameter, the device that deactivated will be
+        single mandatory parameter, the device that deactivated it will be
         passed as that parameter.
 
         Set this property to :data:`None` (the default) to disable the event.

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -238,7 +238,7 @@ class EventsMixin(object):
 
     def _all_events(self):
         """
-        Generator functionw which yields all :class:`event` instances defined
+        Generator function which yields all :class:`event` instances defined
         against this class.
         """
         for name in dir(type(self)):


### PR DESCRIPTION
And clean up event handling generally. All the logic to do with wrapping callbacks, and ensuring watch threads is set up should be handled by the EventsMixin or other helper classes (in this case a property analogue called "event").

Fixes #393