### PR TITLE
Add details about v1.6.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,8 +128,8 @@ Python 2 support
 
 .. warning::
 
-    Version 1.6.0 of GPIO Zero is the last to support Python 2. The next release
-    will be Version 2.0.0 and will support Python 3 only.
+    GPIO Zero 1.6.x is the last to support Python 2. GPIO Zero 2.x will support
+    Python 3 only.
 
 Contributors
 ============

--- a/docs/api_pins.rst
+++ b/docs/api_pins.rst
@@ -134,6 +134,8 @@ they are tried by default.
 +=========+===============================================+===========================================+
 | rpigpio | :class:`gpiozero.pins.rpigpio.RPiGPIOFactory` | :class:`gpiozero.pins.rpigpio.RPiGPIOPin` |
 +---------+-----------------------------------------------+-------------------------------------------+
+| lgpio   | :class:`gpiozero.pins.lgpio.LGPIOFactory`     | :class:`gpiozero.pins.lgpio.LGPIOPin`     |
++---------+-----------------------------------------------+-------------------------------------------+
 | rpio    | :class:`gpiozero.pins.rpio.RPIOFactory`       | :class:`gpiozero.pins.rpio.RPIOPin`       |
 +---------+-----------------------------------------------+-------------------------------------------+
 | pigpio  | :class:`gpiozero.pins.pigpio.PiGPIOFactory`   | :class:`gpiozero.pins.pigpio.PiGPIOPin`   |

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,11 +12,19 @@ Changelog
 
 .. currentmodule:: gpiozero
 
+Release 1.6.2 (2021-03-18)
+==========================
+
+* Correct docs referring to 1.6.0 as the last version supporting Python 2
+
+.. warning::
+
+    This is the last release to support Python 2
+
 Release 1.6.1 (2021-03-17)
 ==========================
 
 * Fix missing font files for 7-segment displays
-
 
 Release 1.6.0 (2021-03-14)
 ==========================
@@ -53,10 +61,6 @@ Release 1.6.0 (2021-03-14)
   `#895`_, `#900`_)
 * Added USB3 and Ethernet speed attributes to :func:`pi_info`
 * Various docs updates
-
-.. warning::
-
-    This is the last release to support Python 2
 
 .. _lgpio: http://abyz.me.uk/lg/py_lgpio.html
 .. _#482: https://github.com/gpiozero/gpiozero/issues/482

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -69,8 +69,8 @@ Python 2/3
 ==========
 
 The library is 100% compatible with both Python 2.7 and Python 3 from version
-3.2 onwards. Since Python 2 is now past its `end-of-life`_, the 1.6.0 release
-(2021-03-14) is the last to support Python 2.
+3.2 onwards. Since Python 2 is now past its `end-of-life`_, the 1.6.2 release
+(2021-03-18) is the last to support Python 2.
 
 
 .. _docs: https://github.com/gpiozero/gpiozero/tree/master/docs

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -213,9 +213,9 @@ version of gpiozero is available in your Python environment like so:
 
     >>> from pkg_resources import require
     >>> require('gpiozero')
-    [gpiozero 1.6.0 (/usr/lib/python3/dist-packages)]
+    [gpiozero 1.6.2 (/usr/lib/python3/dist-packages)]
     >>> require('gpiozero')[0].version
-    '1.6.0'
+    '1.6.2'
 
 If you have multiple versions installed (e.g. from :command:`pip` and
 :command:`apt`) they will not show up in the list returned by the


### PR DESCRIPTION
...and correct docs referring to 1.6.0 as the last version supporting Python 2