### PR TITLE
Robots done right

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         make develop
     - name: Run tests
       run: |

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -138,6 +138,10 @@ enable robot boards now inherit all the functionality of :class:`Robot` because
 that's all they use. Theoretically you could also mix and match regular motors
 and phase-enable motors although there's little sense in doing so.
 
+The former functionality (passing tuples to the :class:`Robot` constructor)
+will remain as deprecated functionality for gpiozero 2.0, but will be removed
+in a future 2.x release.
+
 
 .. _Python documentation: https://docs.python.org/3/
 .. _porting guide: https://docs.python.org/3/howto/pyporting.html

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -3,6 +3,8 @@ Backwards Compatibility
 =======================
 
 
+.. currentmodule:: gpiozero
+
 GPIO Zero 2.x is a new major version and thus backwards incompatible changes
 can be expected. We have attempted to keep these as minimal as reasonably
 possible while taking advantage of the opportunity to clean up things. This
@@ -61,8 +63,8 @@ Keyword arguments
 =================
 
 Many classes in GPIO Zero 1.x were documented as having keyword-only arguments
-in their constructors and methods. For example, the :class:`~gpiozero.PiLiter`
-was documented as having the constructor: ``PiLiter(*, pwm=False,
+in their constructors and methods. For example, the :class:`PiLiter` was
+documented as having the constructor: ``PiLiter(*, pwm=False,
 initial_value=False, pin_factory=None)`` implying that all its arguments were
 keyword only.
 
@@ -85,6 +87,56 @@ However, if you had omitted the keyword you will need to modify your code::
     from gpiozero import PiLiter
 
     l = PiLiter(True)  # this will no longer work
+
+
+Robots take Motors, and PhaseEnableRobot is removed
+===================================================
+
+The GPIO Zero 1.x API specified that a :class:`Robot` was constructed with two
+tuples that were in turn used to construct two :class:`Motor` instances. The
+2.x API replaces this with simply passing in the :class:`Motor`, or
+:class:`PhaseEnableMotor` instances you wish to use as the left and right
+wheels.
+
+If your current code uses pins 4 and 14 for the left wheel, and 17 and 18 for
+the right wheel, it may look like this::
+
+    from gpiozero import Robot
+
+    r = Robot(left=(4, 14), right=(17, 18))
+
+This should be changed to the following::
+
+    from gpiozero import Robot, Motor
+
+    r = Robot(left=Motor(4, 14), right=Motor(17, 18))
+
+Likewise, if you are currently using :class:`PhaseEnableRobot` your code may
+look like this::
+
+    from gpiozero import PhaseEnableRobot
+
+    r = PhaseEnableRobot(left=(4, 14), right=(17, 18))
+
+This should be changed to the following::
+
+    from gpiozero import Robot, PhaseEnableMotor
+
+    r = Robot(left=PhaseEnableMotor(4, 14),
+              right=PhaseEnableMotor(17, 18))
+
+This change came about because the :class:`Motor` class was also documented as
+having two mandatory parameters (*forward* and *backward*) and several
+keyword-only parameters, including the *enable* pin. However, *enable* was
+treated as a positional argument for the sake of constructing :class:`Robot`
+which was inconsistent. Furthermore, :class:`PhaseEnableRobot` was more or less
+a redundant duplicate of :class:`Robot` but was lacking a couple of features
+added to :class:`Robot` later (notable "curved" turning).
+
+Although the new API requires a little more typing, it does mean that phase
+enable robot boards now inherit all the functionality of :class:`Robot` because
+that's all they use. Theoretically you could also mix and match regular motors
+and phase-enable motors although there's little sense in doing so.
 
 
 .. _Python documentation: https://docs.python.org/3/

--- a/docs/examples/bluedot_robot_1.py
+++ b/docs/examples/bluedot_robot_1.py
@@ -1,9 +1,9 @@
 from bluedot import BlueDot
-from gpiozero import Robot
+from gpiozero import Robot, Motor
 from signal import pause
 
 bd = BlueDot()
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 def move(pos):
     if pos.top:

--- a/docs/examples/bluedot_robot_2.py
+++ b/docs/examples/bluedot_robot_2.py
@@ -1,4 +1,4 @@
-from gpiozero import Robot
+from gpiozero import Robot, Motor
 from bluedot import BlueDot
 from signal import pause
 
@@ -18,7 +18,7 @@ def drive():
         else:
             yield (0, 0)
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 bd = BlueDot()
 
 robot.source = drive()

--- a/docs/examples/remote_button_robot.py
+++ b/docs/examples/remote_button_robot.py
@@ -1,9 +1,10 @@
-from gpiozero import Button, Robot
+from gpiozero import Button, Robot, Motor
 from gpiozero.pins.pigpio import PiGPIOFactory
 from signal import pause
 
 factory = PiGPIOFactory(host='192.168.1.17')
-robot = Robot(left=(4, 14), right=(17, 18), pin_factory=factory)  # remote pins
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18),
+              pin_factory=factory)  # remote pins
 
 # local buttons
 left = Button(26)

--- a/docs/examples/robot_1.py
+++ b/docs/examples/robot_1.py
@@ -1,7 +1,7 @@
-from gpiozero import Robot
+from gpiozero import Robot, Motor
 from time import sleep
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 for i in range(4):
     robot.forward()

--- a/docs/examples/robot_2.py
+++ b/docs/examples/robot_2.py
@@ -1,8 +1,8 @@
-from gpiozero import Robot, DistanceSensor
+from gpiozero import Robot, Motor, DistanceSensor
 from signal import pause
 
 sensor = DistanceSensor(23, 24, max_distance=1, threshold_distance=0.2)
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 sensor.when_in_range = robot.backward
 sensor.when_out_of_range = robot.stop

--- a/docs/examples/robot_buttons_1.py
+++ b/docs/examples/robot_buttons_1.py
@@ -1,7 +1,7 @@
-from gpiozero import Robot, Button
+from gpiozero import Robot, Motor, Button
 from signal import pause
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 left = Button(26)
 right = Button(16)

--- a/docs/examples/robot_buttons_2.py
+++ b/docs/examples/robot_buttons_2.py
@@ -1,8 +1,8 @@
-from gpiozero import Button, Robot
+from gpiozero import Button, Robot, Motor
 from time import sleep
 from signal import pause
 
-robot = Robot((17, 18), (22, 23))
+robot = Robot(Motor(17, 18), Motor(22, 23))
 
 left = Button(2)
 right = Button(3)

--- a/docs/examples/robot_keyboard_1.py
+++ b/docs/examples/robot_keyboard_1.py
@@ -1,7 +1,7 @@
 import curses
-from gpiozero import Robot
+from gpiozero import Robot, Motor
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 actions = {
     curses.KEY_UP:    robot.forward,

--- a/docs/examples/robot_keyboard_2.py
+++ b/docs/examples/robot_keyboard_2.py
@@ -1,7 +1,7 @@
-from gpiozero import Robot
+from gpiozero import Robot, Motor
 from evdev import InputDevice, list_devices, ecodes
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 # Get the list of available input devices
 devices = [InputDevice(device) for device in list_devices()]

--- a/docs/examples/robot_motion_1.py
+++ b/docs/examples/robot_motion_1.py
@@ -1,7 +1,7 @@
-from gpiozero import Robot, MotionSensor
+from gpiozero import Robot, Motor, MotionSensor
 from signal import pause
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 pir = MotionSensor(5)
 
 pir.when_motion = robot.forward

--- a/docs/examples/robot_motion_2.py
+++ b/docs/examples/robot_motion_2.py
@@ -1,8 +1,8 @@
-from gpiozero import Robot, MotionSensor
+from gpiozero import Robot, Motor, MotionSensor
 from gpiozero.tools import zip_values
 from signal import pause
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 pir = MotionSensor(5)
 
 robot.source = zip_values(pir, pir)

--- a/docs/examples/robot_pots_1.py
+++ b/docs/examples/robot_pots_1.py
@@ -1,8 +1,8 @@
-from gpiozero import Robot, MCP3008
+from gpiozero import Robot, Motor, MCP3008
 from gpiozero.tools import zip_values
 from signal import pause
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 left_pot = MCP3008(0)
 right_pot = MCP3008(1)

--- a/docs/examples/robot_pots_2.py
+++ b/docs/examples/robot_pots_2.py
@@ -1,8 +1,8 @@
-from gpiozero import Robot, MCP3008
+from gpiozero import Robot, Motor, MCP3008
 from gpiozero.tools import scaled
 from signal import pause
 
-robot = Robot(left=(4, 14), right=(17, 18))
+robot = Robot(left=Motor(4, 14), right=Motor(17, 18))
 
 left_pot = MCP3008(0)
 right_pot = MCP3008(1)

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -110,7 +110,6 @@ from .boards import (
     Robot,
     RyanteckRobot,
     CamJamKitRobot,
-    PhaseEnableRobot,
     PololuDRV8835Robot,
     Energenie,
     PumpkinPi,

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -17,6 +17,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from time import sleep
 from itertools import repeat, cycle, chain, tee
 from threading import Lock
@@ -2120,9 +2121,25 @@ class Robot(SourceMixin, CompositeDevice):
     """
     def __init__(self, left, right, *, pin_factory=None):
         if not isinstance(left, (Motor, PhaseEnableMotor)):
-            raise GPIOPinMissing('left must be a Motor or PhaseEnableMotor')
+            if isinstance(left, tuple):
+                warnings.warn(
+                    DeprecationWarning(
+                        "Passing a tuple as the left parameter of the Robot "
+                        "constructor is deprecated; please pass a Motor or "
+                        "PhaseEnableMotor instance instead"))
+                left = Motor(*left)
+            else:
+                raise GPIOPinMissing('left must be a Motor or PhaseEnableMotor')
         if not isinstance(right, (Motor, PhaseEnableMotor)):
-            raise GPIOPinMissing('right must be a Motor or PhaseEnableMotor')
+            if isinstance(right, tuple):
+                warnings.warn(
+                    DeprecationWarning(
+                        "Passing a tuple as the right parameter of the Robot "
+                        "constructor is deprecated; please pass a Motor or "
+                        "PhaseEnableMotor instance instead"))
+                right = Motor(*right)
+            else:
+                raise GPIOPinMissing('right must be a Motor or PhaseEnableMotor')
         super().__init__(left_motor=left, right_motor=right,
                          _order=('left_motor', 'right_motor'),
                          pin_factory=pin_factory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ gpiozero_mock_pin_classes =
     mockchargingpin  = gpiozero.pins.mock:MockChargingPin
     mocktriggerpin   = gpiozero.pins.mock:MockTriggerPin
 
-[tools:pytest]
+[tool:pytest]
 addopts = -rsx --cov --tb=short
 testpaths = tests
 

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -899,17 +899,14 @@ def test_traffic_phat(mock_factory):
         assert repr(board).startswith('<gpiozero.TrafficpHat object')
         assert ([led.pin for led in board]) == pins
 
-def test_robot_bad_init(mock_factory):
-    with pytest.raises(GPIOPinMissing):
+def test_robot_bad_init(mock_factory, pwm):
+    pins = [mock_factory.pin(n) for n in (2, 3)]
+    with pytest.raises(TypeError):
         Robot()
     with pytest.raises(GPIOPinMissing):
-        Robot(2)
+        Robot(Motor(2, 3), (4, 5))
     with pytest.raises(GPIOPinMissing):
-        Robot(2, 3)
-    with pytest.raises(GPIOPinMissing):
-        Robot((2, 3))
-    with pytest.raises(GPIOPinMissing):
-        Robot((2, 3), 4)
+        Robot((4, 5), Motor(2, 3))
 
 def test_robot(mock_factory, pwm):
     pins = [mock_factory.pin(n) for n in (2, 3, 4, 5)]
@@ -920,7 +917,7 @@ def test_robot(mock_factory, pwm):
         assert robot.value == (
             pins[0].state - pins[1].state, pins[2].state - pins[3].state
         ) == expected_value
-    with Robot((2, 3), (4, 5)) as robot:
+    with Robot(Motor(2, 3), Motor(4, 5)) as robot:
         assert repr(robot).startswith('<gpiozero.Robot object')
         assert (
             [device.pin for device in robot.left_motor] +
@@ -1089,7 +1086,7 @@ def test_robots(mock_factory, pwm):
 
 def test_robot_nopwm(mock_factory):
     pins = [mock_factory.pin(n) for n in (2, 3, 4, 5)]
-    with Robot((2, 3), (4, 5), pwm=False) as robot:
+    with Robot(Motor(2, 3, pwm=False), Motor(4, 5, pwm=False)) as robot:
         left_motor, right_motor = robot.all
         assert isinstance(left_motor, Motor)
         assert left_motor.forward_device.pin is pins[0]
@@ -1141,7 +1138,7 @@ def test_robots_nopwm(mock_factory):
 
 def test_enable_pin_motor_robot(mock_factory, pwm):
     pins = [mock_factory.pin(n) for n in (2, 3, 4, 5, 6, 7)]
-    with Robot((2, 3, 4), (5, 6, 7)) as robot:
+    with Robot(Motor(2, 3, enable=4), Motor(5, 6, enable=7)) as robot:
         left_motor, right_motor = robot.all
         assert isinstance(left_motor, Motor)
         assert left_motor.forward_device.pin is pins[0]
@@ -1160,7 +1157,8 @@ def test_enable_pin_motor_robot(mock_factory, pwm):
 
 def test_enable_pin_motor_robot_nopwm(mock_factory):
     pins = [mock_factory.pin(n) for n in (2, 3, 4, 5, 6, 7)]
-    with Robot((2, 3, 4), (5, 6, 7), pwm=False) as robot:
+    with Robot(Motor(2, 3, enable=4, pwm=False),
+               Motor(5, 6, enable=7, pwm=False)) as robot:
         left_motor, right_motor = robot.all
         assert isinstance(left_motor, Motor)
         assert left_motor.forward_device.pin is pins[0]
@@ -1176,54 +1174,6 @@ def test_enable_pin_motor_robot_nopwm(mock_factory):
         assert isinstance(right_motor.backward_device, DigitalOutputDevice)
         assert right_motor.enable_device.pin is pins[5]
         assert isinstance(right_motor.enable_device, DigitalOutputDevice)
-
-def test_phaseenable_robot_bad_init(mock_factory):
-    with pytest.raises(GPIOPinMissing):
-        PhaseEnableRobot()
-    with pytest.raises(GPIOPinMissing):
-        PhaseEnableRobot(2)
-    with pytest.raises(GPIOPinMissing):
-        PhaseEnableRobot(2, 3)
-    with pytest.raises(GPIOPinMissing):
-        PhaseEnableRobot((2, 3))
-    with pytest.raises(GPIOPinMissing):
-        PhaseEnableRobot((2, 3), 4)
-
-def test_phaseenable_robot(mock_factory, pwm):
-    pins = [mock_factory.pin(n) for n in (5, 12, 6, 13)]
-    with PhaseEnableRobot((5, 12), (6, 13)) as robot:
-        assert repr(robot).startswith('<gpiozero.PhaseEnableRobot object')
-        assert (
-            [device.pin for device in robot.left_motor] +
-            [device.pin for device in robot.right_motor]) == pins
-        assert robot.value == (0, 0)
-        robot.forward()
-        assert [pin.state for pin in pins] == [0, 1, 0, 1]
-        assert robot.value == (1, 1)
-        robot.backward()
-        assert [pin.state for pin in pins] == [1, 1, 1, 1]
-        assert robot.value == (-1, -1)
-        robot.forward(0.5)
-        assert [pin.state for pin in pins] == [0, 0.5, 0, 0.5]
-        assert robot.value == (0.5, 0.5)
-        robot.left()
-        assert [pin.state for pin in pins] == [1, 1, 0, 1]
-        assert robot.value == (-1, 1)
-        robot.right()
-        assert [pin.state for pin in pins] == [0, 1, 1, 1]
-        assert robot.value == (1, -1)
-        robot.reverse()
-        assert [pin.state for pin in pins] == [1, 1, 0, 1]
-        assert robot.value == (-1, 1)
-        robot.stop()
-        assert [pin.state for pin in pins][1::2] == [0, 0]
-        assert robot.value == (0, 0)
-        robot.value = (-1, -1)
-        assert robot.value == (-1, -1)
-        robot.value = (0.5, 1)
-        assert robot.value == (0.5, 1)
-        robot.value = (0, -0.5)
-        assert robot.value == (0, -0.5)
 
 def test_energenie_bad_init(mock_factory):
     with pytest.raises(ValueError):

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -16,6 +16,7 @@
 
 import sys
 import pytest
+import warnings
 from time import sleep
 from threading import Event
 
@@ -904,9 +905,18 @@ def test_robot_bad_init(mock_factory, pwm):
     with pytest.raises(TypeError):
         Robot()
     with pytest.raises(GPIOPinMissing):
-        Robot(Motor(2, 3), (4, 5))
+        Robot(Motor(2, 3), None)
     with pytest.raises(GPIOPinMissing):
-        Robot((4, 5), Motor(2, 3))
+        Robot(None, Motor(2, 3))
+
+def test_robot_deprecation(mock_factory, pwm):
+    pins = [mock_factory.pin(n) for n in (2, 3, 4, 5)]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.resetwarnings()
+        with Robot((2, 3), (4, 5)) as robot:
+            assert len(w) == 2
+            assert w[0].category == DeprecationWarning
+            assert w[1].category == DeprecationWarning
 
 def test_robot(mock_factory, pwm):
     pins = [mock_factory.pin(n) for n in (2, 3, 4, 5)]


### PR DESCRIPTION
A probably controversial change for 2.x, hence @bennuttall ought to decide whether or not this should go in. `PhaseEnableRobot` is basically a redundant duplicate of `Robot`. However, `Robot` has grown several features which haven't been copied over to `PhaseEnableRobot` (notably curved cornering). Moreover, when I implemented "proper" keyword-args after we dropped py2.x support several tests failed because we were assuming that the "enable" parameter for Motor, which we'd documented (though not enforced) as keyword-only, was positional and could be represented as a tuple.

A cleaner solution all round is to ditch `PhaseEnableRobot` (removing the duplication), and just have Robot constructed from two `Motor`s *or* `PhaseEnableMotor`s (or, weirdly a mix-and-match, although that's probably not very practical). After all, Robot doesn't really care *what* left and right motors it has as long as they can go "forwards" or "backwards" (in other words as long as they're objects with those methods).

However, as noted this *is* a breaking change - it'll break the code of anyone currently using `Robot`. Potentially, we *could* alleviate some of that by, say, detecting tuples being passed in and implicitly converting them to a `Motor` instance but of course that doesn't solve the breakage for anyone using `PhaseEnableMotor`.

The PR's also incomplete: I haven't gotten around to updating the recipes/examples code - but there is an entry in the deprecation chapter. Let me know if you think it's worth finishing it off or if it would be acceptable but needs the mitigations mentioned above added.