### PR TITLE
Installed by default on Lite now, too

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -9,10 +9,9 @@
 Installing GPIO Zero
 ====================
 
-GPIO Zero is installed by default in the `Raspberry Pi OS`_ desktop image, and
-the `Raspberry Pi Desktop`_ image for PC/Mac, both available from
-`raspberrypi.org`_. Follow these guides to installing on Raspberry Pi OS Lite
-and other operating systems, including for PCs using the :doc:`remote GPIO
+GPIO Zero is installed by default in the `Raspberry Pi OS`_ desktop image,  `Raspberry Pi OS`_ Lite image, and
+the `Raspberry Pi Desktop`_ image for PC/Mac, all available from
+`raspberrypi.org`_. Follow these guides to installing on other operating systems, including for PCs using the :doc:`remote GPIO
 <remote_gpio>` feature.
 
 .. _Raspberry Pi OS: https://www.raspberrypi.org/software/operating-systems/


### PR DESCRIPTION
Noticed the [changelog](https://downloads.raspberrypi.org/raspios_lite_armhf/release_notes.txt) mention that this lib is now available by default on Lite, too. I tested this locally as well - I was able to `import gpiozero` without having to pip install it. 