### PR TITLE
Add a `fade_to` method to PWMOutputDevice

### DIFF
--- a/docs/api_output.rst
+++ b/docs/api_output.rst
@@ -41,14 +41,14 @@ PWMLED
 ------
 
 .. autoclass:: PWMLED
-    :members: on, off, toggle, blink, pulse, pin, is_lit, value
+    :members: on, off, toggle, blink, pulse, fade_to, pin, is_lit, value
 
 
 RGBLED
 ------
 
 .. autoclass:: RGBLED
-    :members: on, off, toggle, blink, pulse, fade_to, red, green, blue, is_lit, color, value
+    :members: on, off, toggle, blink, pulse, fade_to, cylcle_color, red, green, blue, is_lit, color, value
 
 
 Buzzer

--- a/docs/api_output.rst
+++ b/docs/api_output.rst
@@ -48,7 +48,7 @@ RGBLED
 ------
 
 .. autoclass:: RGBLED
-    :members: on, off, toggle, blink, pulse, red, green, blue, is_lit, color, value
+    :members: on, off, toggle, blink, pulse, fade_to, red, green, blue, is_lit, color, value
 
 
 Buzzer

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1184,8 +1184,8 @@ class RGBLED(SourceMixin, Device):
         """
         Cycle the hue, while keeping saturation and value constant (hsv color model).
         Caution: Only the hue parameter will change. This means, that the luminescence will stay
-        the same, so white will stay white and black will stay black. For best (i.e. most colorful)
-        results, use a pure color as a starting value.
+        the same, so full white (1,1,1) will stay white and black (i.e. off) will stay black. 
+        For best (i.e. most colorful) results, use a pure color (e.g. (1,0,0) ) as a starting value.
 
         :param float cycle_time:
             Time in seconds to complete one cycle. Defaults to 10
@@ -1197,9 +1197,8 @@ class RGBLED(SourceMixin, Device):
 
         :param bool clockwise:
             Gives the direction of the rotation. :data: `True` (the default) means clockwise 
-            in the hsw colorwheel arbraum - – Wikipedia
-https://de.wikipedia.org › wiki › HSV-Farbraum
-Der HSV(Red->Green->Blue->Red).
+            in the hsv colorwheel (Red->Green->Blue->Red).
+            Further information on HSV: https://en.wikipedia.org/wiki/HSL_and_HSV
 
         :type n: int or None
         :param n:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1183,6 +1183,9 @@ class RGBLED(SourceMixin, Device):
     def cycle_color(self, cycle_time=10, start_color=None, clockwise=True, n=None, background=True):
         """
         Cycle the hue, while keeping saturation and value constant (hsv color model).
+        Caution: Only the hue parameter will change. This means, that the luminescence will stay
+        the same, so white will stay white and black will stay black. For best (i.e. most colorful)
+        results, use a pure color as a starting value.
 
         :param float cycle_time:
             Time in seconds to complete one cycle. Defaults to 10
@@ -1193,7 +1196,10 @@ class RGBLED(SourceMixin, Device):
             means start at current color.
 
         :param bool clockwise:
-            Gives the direction of the rotation. `True` (the default) means clockwise (Red->Green->Blue->Red).
+            Gives the direction of the rotation. :data: `True` (the default) means clockwise 
+            in the hsw colorwheel arbraum - – Wikipedia
+https://de.wikipedia.org › wiki › HSV-Farbraum
+Der HSV(Red->Green->Blue->Red).
 
         :type n: int or None
         :param n:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1185,7 +1185,7 @@ class RGBLED(SourceMixin, Device):
         Cycle the hue, while keeping saturation and value constant (hsv color model).
         Caution: Only the hue parameter will change. This means, that the luminescence will stay
         the same, so full white (1,1,1) will stay white and black (i.e. off) will stay black. 
-        For best (i.e. most colorful) results, use a pure color (e.g. `(1,0,0) ) as a starting value.
+        For best (i.e. most colorful) results, use a pure color (e.g. `(1,0,0)` ) as a starting value.
 
         :param float cycle_time:
             Time in seconds to complete one cycle. Defaults to 10

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1209,7 +1209,7 @@ class RGBLED(SourceMixin, Device):
         self._stop_blink()
         self._blink_thread = GPIOThread(
             self._cycle_color_device,
-            (fade_time, start_color, end_color)
+            (cycle_time, start_color, clockwise, n)
         )
         self._blink_thread.start()
         if not background:
@@ -1294,7 +1294,7 @@ class RGBLED(SourceMixin, Device):
                 break
                 
     def _cycle_color_device(
-            self, cycle_time, start_color, clockwise):
+            self, cycle_time, start_color, clockwise, n, fps=25):
         if start_color is None:
             color = Color(self.value)
         else:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1184,7 +1184,7 @@ class RGBLED(SourceMixin, Device):
         """
         Cycle the hue, while keeping saturation and value constant (hsv color model).
         Caution: Only the hue parameter will change. This means, that the luminescence will stay
-        the same, so full white (1,1,1) will stay white and black (i.e. off) will stay black. 
+        the same, so full white `(1,1,1)` will stay white and black (i.e. off) will stay black. 
         For best (i.e. most colorful) results, use a pure color (e.g. `(1,0,0)` ) as a starting value.
 
         :param float cycle_time:

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1238,16 +1238,14 @@ class RGBLED(SourceMixin, Device):
             begin_color = self.value
         else:
             begin_color = start_color
-        lerp = lambda t, fade_in: tuple(
+        lerp = lambda t: tuple(
             (1 - t) * begin + t * end
-            if fade_in else
-            (1 - t) * end + t * begin
             for end, begin in zip(end_color, begin_color)
             )
         sequence = []
         if fade_time > 0:
             sequence += [
-                (lerp(i * (1 / fps) / fade_time, True), 1 / fps)
+                (lerp(i * (1 / fps) / fade_time), 1 / fps)
                 for i in range(int(fps * fade_time))
                 ]
             sequence.append((end_color,0))

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -539,7 +539,7 @@ class PWMOutputDevice(OutputDevice):
         """
         Make the device fade smoothly to a given value.
         
-        :param float fade_in_time:
+        :param float fade_time:
             Time in seconds to fade in. Defaults to 1
         
         :type start_value: float or None
@@ -1152,10 +1152,10 @@ class RGBLED(SourceMixin, Device):
         """
         Make the device fade smoothly to a given value.
         
-        :param float fade_in_time:
+        :param float fade_time:
             Time in seconds to fade in. Defaults to 1
         
-        :type atart_color: float or ~colorzero.Color or None
+        :type start_color: float or ~colorzero.Color or None
         :param start:
             Gives the color at which the fade starts; :data: `None` (the default) 
             means start at current value

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -535,7 +535,7 @@ class PWMOutputDevice(OutputDevice):
             on_time, off_time, fade_in_time, fade_out_time, n, background
         )
 
-    def fade_to(self, fade_time=1, start_value=None, end_value=1, background=True)
+    def fade_to(self, fade_time=1, start_value=None, end_value=1, background=True):
         """
         Make the device fade smoothly to a given value.
         

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1155,7 +1155,7 @@ class RGBLED(SourceMixin, Device):
         :param float fade_time:
             Time in seconds to fade in. Defaults to 1
         
-        :type start_color: float or ~colorzero.Color or None
+        :type start_color: tuple or ~colorzero.Color or None
         :param start:
             Gives the color at which the fade starts; :data: `None` (the default) 
             means start at current value

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -600,9 +600,9 @@ class PWMOutputDevice(OutputDevice):
                 
     def _fade_to_device(
             self, fade_time, start_value, end_value, fps=25):
-        if start_value is None
+        if start_value is None:
             begin_value = super().value
-        else
+        else:
             begin_value = start_value
         sequence = []
         if fade_time > 0:
@@ -1233,9 +1233,9 @@ class RGBLED(SourceMixin, Device):
             self, fade_time, start_color, end_color, fps=25):
         # Define a simple lambda to perform linear interpolation between
         # off_color and on_color
-        if start_color is None
+        if start_color is None:
             begin_color = super().value
-        else
+        else:
             begin_color = start_color
         lerp = lambda t, fade_in: tuple(
             (1 - t) * end + t * begin

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -538,24 +538,24 @@ class PWMOutputDevice(OutputDevice):
     def fade_to(self, fade_time=1, start_value=None, end_value=1, background=True):
         """
         Make the device fade smoothly to a given value.
-        
+
         :param float fade_time:
             Time in seconds to fade in. Defaults to 1
-        
+
         :type start_value: float or None
         :param start:
             Gives the value at which the fade starts; :data: `None` (the default) 
             means start at current value
-        
+
         :param float end:
             Gives the value at which the fade should end
-            
+
         :param bool background:
             If :data:`True` (the default), start a background thread to
             continue fading and return immediately. If :data:`False`, only
             return when the fade is finished.
         """
-        
+
         self._stop_blink()
         self._blink_thread = GPIOThread(
             self._fade_to_device,
@@ -565,7 +565,7 @@ class PWMOutputDevice(OutputDevice):
         if not background:
             self._blink_thread.join()
             self._blink_thread = None
-            
+
     def _stop_blink(self):
         if self._controller:
             self._controller._stop_blink(self)
@@ -573,7 +573,7 @@ class PWMOutputDevice(OutputDevice):
         if self._blink_thread:
             self._blink_thread.stop()
             self._blink_thread = None
-            
+
     def _blink_device(
             self, on_time, off_time, fade_in_time, fade_out_time, n, fps=25):
         sequence = []
@@ -597,7 +597,7 @@ class PWMOutputDevice(OutputDevice):
             self._write(value)
             if self._blink_thread.stopping.wait(delay):
                 break
-                
+
     def _fade_to_device(
             self, fade_time, start_value, end_value, fps=25):
         if start_value is None:
@@ -615,7 +615,7 @@ class PWMOutputDevice(OutputDevice):
             self._write(value)
             if self._blink_thread.stopping.wait(delay):
                 break
-         
+
 
 class TonalBuzzer(SourceMixin, CompositeDevice):
     """
@@ -1151,19 +1151,19 @@ class RGBLED(SourceMixin, Device):
     def fade_to(self, fade_time=1, start_color=None, end_color=(1,1,1), background=True):
         """
         Make the device fade smoothly to a given value.
-        
+
         :param float fade_time:
-            Time in seconds to fade in. Defaults to 1
-        
+            Time in seconds to fade in. Defaults to 1.
+
         :type start_color: tuple or ~colorzero.Color or None
         :param start:
             Gives the color at which the fade starts; :data: `None` (the default) 
-            means start at current value
-        
+            means start at current value.
+
         :type end_color: ~colorzero.Color or tuple
         :param end_color:
-            Gives the color at which the fade should end
-            
+            Gives the color at which the fade should end.
+
         :param bool background:
             If :data:`True` (the default), start a background thread to
             continue fading and return immediately. If :data:`False`, only
@@ -1183,17 +1183,17 @@ class RGBLED(SourceMixin, Device):
     def cycle_color(self, cycle_time=10, start_color=None, clockwise=True, n=None, background=True):
         """
         Cycle the hue, while keeping saturation and value constant (hsv color model).
-        
+
         :param float cycle_time:
-            Time in seconds complete one cycle. Defaults to 10
+            Time in seconds to complete one cycle. Defaults to 10
 
         :type start_color: tuple or ~colorzero.Color or None
         :param start:
             Gives the color at which the fade starts; :data: `None` (the default) 
-            means start at current color
+            means start at current color.
 
         :param bool clockwise:
-            Gives the direction of the rotation. `True` (the default) means clockwise (Red->Green->Blue->Red)
+            Gives the direction of the rotation. `True` (the default) means clockwise (Red->Green->Blue->Red).
 
         :type n: int or None
         :param n:
@@ -1201,7 +1201,7 @@ class RGBLED(SourceMixin, Device):
 
         :param bool background:
             If :data:`True` (the default), start a background thread to
-            continue fading and return immediately. If :data:`False`, only
+            continue cycling and return immediately. If :data:`False`, only
             return when the cycles are finished. (warning: the default value of
             *n* will result in this method never returning).
         """
@@ -1215,7 +1215,7 @@ class RGBLED(SourceMixin, Device):
         if not background:
             self._blink_thread.join()
             self._blink_thread = None            
-            
+
     def _stop_blink(self):
         if self._controller:
             self._controller._stop_blink(self)
@@ -1223,7 +1223,7 @@ class RGBLED(SourceMixin, Device):
         if self._blink_thread:
             self._blink_thread.stop()
             self._blink_thread = None                
-                
+
     def _stop_blink(self, led=None):
         # If this is called with a single led, we stop all blinking anyway
         if self._blink_thread:
@@ -1265,7 +1265,7 @@ class RGBLED(SourceMixin, Device):
                 l._write(v)
             if self._blink_thread.stopping.wait(delay):
                 break
-                
+
     def _fade_to_device(
             self, fade_time, start_color, end_color, fps=25):
         # Define a simple lambda to perform linear interpolation between
@@ -1292,14 +1292,14 @@ class RGBLED(SourceMixin, Device):
                 l._write(v)
             if self._blink_thread.stopping.wait(delay):
                 break
-                
+
     def _cycle_color_device(
             self, cycle_time, start_color, clockwise, n, fps=25):
         if start_color is None:
             color = Color(self.value)
         else:
             color = Color(start_color)
-        direction = -1 + 2 * clockwise
+        direction = 1 if clockwise else -1
         sequence = []
         if cycle_time > 0:
             sequence += [
@@ -1318,7 +1318,7 @@ class RGBLED(SourceMixin, Device):
                 l._write(v)
             if self._blink_thread.stopping.wait(delay):
                 break
-       
+
 
 class Motor(SourceMixin, CompositeDevice):
     """

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1185,7 +1185,7 @@ class RGBLED(SourceMixin, Device):
         Cycle the hue, while keeping saturation and value constant (hsv color model).
         Caution: Only the hue parameter will change. This means, that the luminescence will stay
         the same, so full white (1,1,1) will stay white and black (i.e. off) will stay black. 
-        For best (i.e. most colorful) results, use a pure color (e.g. (1,0,0) ) as a starting value.
+        For best (i.e. most colorful) results, use a pure color (e.g. `(1,0,0) ) as a starting value.
 
         :param float cycle_time:
             Time in seconds to complete one cycle. Defaults to 10


### PR DESCRIPTION
Add a "fade_to()" function to the PWMOutputDevice class as well as a mod RGBLED. It uses the same blink thread as the blink function to not interfere with existing scripts.
This function takes a fade_time in seconds and fades the value/color from a start value (default: the given value at the moment) to an end value.