### PR TITLE
Add support for lgpio 0.2

### DIFF
--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -33,6 +33,11 @@ from ..exc import (
     DeviceClosed
 )
 
+# lgpio 0.2 has changed these to new names
+if hasattr(lgpio, "SET_PULL_NONE"):
+    lgpio.SET_BIAS_DISABLE = lgpio.SET_PULL_NONE
+    lgpio.SET_BIAS_PULL_DOWN = lgpio.SET_PULL_DOWN
+    lgpio.SET_BIAS_PULL_UP = lgpio.SET_PULL_UP
 
 class LGPIOFactory(LocalPiFactory):
     """


### PR DESCRIPTION
Add support for lgpio 0.2 since it changed the names of the `SET_BIAS_` constants

- Closes #1038 