### PR TITLE
Add I2C support and support for INA219 device (from pi-ina219)

### DIFF
--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -72,6 +72,7 @@ from .spi_devices import (
 )
 from .i2c_devices import (
     I2CDevice,
+    INA219
 )
 from .output_devices import (
     OutputDevice,

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -70,6 +70,9 @@ from .spi_devices import (
     MCP3302,
     MCP3304,
 )
+from .i2c_devices import (
+    I2CDevice,
+)
 from .output_devices import (
     OutputDevice,
     DigitalOutputDevice,

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -79,6 +79,12 @@ class SPIFixedRate(SPIError, AttributeError):
 class SPIInvalidWordSize(SPIError, ValueError):
     "Error raised when an invalid (out of range) number of bits per word is specified"
 
+class I2CError(GPIOZeroError):
+    "Base class for errors related to the I2C implementation"
+
+class I2CBadArgs(I2CError, ValueError):
+    "Error raised when invalid arguments are given while constructing :class:`I2CDevice`"
+
 class GPIODeviceError(GPIOZeroError):
     "Base class for errors specific to the GPIODevice hierarchy"
 
@@ -165,6 +171,12 @@ class SPIWarning(GPIOZeroWarning):
 
 class SPISoftwareFallback(SPIWarning):
     "Warning raised when falling back to the SPI software implementation"
+
+class I2CWarning(GPIOZeroWarning):
+    "Base class for warnings related to the I2C implementation"
+
+class I2CSoftwareFallback(I2CWarning):
+    "Warning raised when falling back to the I2C software implementation"
 
 class PWMWarning(GPIOZeroWarning):
     "Base class for PWM warnings"

--- a/gpiozero/i2c_devices.py
+++ b/gpiozero/i2c_devices.py
@@ -9,6 +9,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from math import trunc
+import time
 from .devices import Device
 from .exc import DeviceClosed, GPIOZeroError
 
@@ -45,3 +47,345 @@ class I2CDevice(Device):
             )
         except DeviceClosed:
             return "<gpiozero.{self.__class__.__name__} object " "closed>".format(self=self)
+
+
+class INA219(I2CDevice):
+    """
+    Extends :class:`I2CDevice` to implement an interface for the INA219.
+
+    This implementation is entirely taken from chrisb2's pi_ina219 project
+    (https://github.com/chrisb2/pi_ina219/) and only modified to fit into
+    the framework.
+    """
+
+    RANGE_16V = 0  # Range 0-16 volts
+    RANGE_32V = 1  # Range 0-32 volts
+
+    GAIN_1_40MV = 0  # Maximum shunt voltage 40mV
+    GAIN_2_80MV = 1  # Maximum shunt voltage 80mV
+    GAIN_4_160MV = 2  # Maximum shunt voltage 160mV
+    GAIN_8_320MV = 3  # Maximum shunt voltage 320mV
+    GAIN_AUTO = -1  # Determine gain automatically
+
+    ADC_9BIT = 0  # 9-bit conversion time  84us.
+    ADC_10BIT = 1  # 10-bit conversion time 148us.
+    ADC_11BIT = 2  # 11-bit conversion time 2766us.
+    ADC_12BIT = 3  # 12-bit conversion time 532us.
+    ADC_2SAMP = 9  # 2 samples at 12-bit, conversion time 1.06ms.
+    ADC_4SAMP = 10  # 4 samples at 12-bit, conversion time 2.13ms.
+    ADC_8SAMP = 11  # 8 samples at 12-bit, conversion time 4.26ms.
+    ADC_16SAMP = 12  # 16 samples at 12-bit,conversion time 8.51ms
+    ADC_32SAMP = 13  # 32 samples at 12-bit, conversion time 17.02ms.
+    ADC_64SAMP = 14  # 64 samples at 12-bit, conversion time 34.05ms.
+    ADC_128SAMP = 15  # 128 samples at 12-bit, conversion time 68.10ms.
+
+    __ADDRESS = 0x40
+
+    __REG_CONFIG = 0x00
+    __REG_SHUNTVOLTAGE = 0x01
+    __REG_BUSVOLTAGE = 0x02
+    __REG_POWER = 0x03
+    __REG_CURRENT = 0x04
+    __REG_CALIBRATION = 0x05
+
+    __RST = 15
+    __BRNG = 13
+    __PG1 = 12
+    __PG0 = 11
+    __BADC4 = 10
+    __BADC3 = 9
+    __BADC2 = 8
+    __BADC1 = 7
+    __SADC4 = 6
+    __SADC3 = 5
+    __SADC2 = 4
+    __SADC1 = 3
+    __MODE3 = 2
+    __MODE2 = 1
+    __MODE1 = 0
+
+    __OVF = 1
+    __CNVR = 2
+
+    __BUS_RANGE = [16, 32]
+    __GAIN_VOLTS = [0.04, 0.08, 0.16, 0.32]
+
+    __CONT_SH_BUS = 7
+
+    __SHUNT_MILLIVOLTS_LSB = 0.01  # 10uV
+    __BUS_MILLIVOLTS_LSB = 4  # 4mV
+    __CALIBRATION_FACTOR = 0.04096
+    __MAX_CALIBRATION_VALUE = 0xFFFE  # Max value supported (65534 decimal)
+    # In the spec (p17) the current LSB factor for the minimum LSB is
+    # documented as 32767, but a larger value (100.1% of 32767) is used
+    # to guarantee that current overflow can always be detected.
+    __CURRENT_LSB_FACTOR = 32800
+
+    def __init__(self, shunt_ohms, max_expected_amps=None, **i2c_args):
+        """Construct the class.
+
+        Pass in the resistance of the shunt resistor and the maximum expected
+        current flowing through it in your system.
+
+        Arguments:
+        shunt_ohms -- value of shunt resistor in Ohms (mandatory).
+        max_expected_amps -- the maximum expected current in Amps (optional).
+        """
+        super().__init__(**i2c_args)
+        self._shunt_ohms = shunt_ohms
+        self._max_expected_amps = max_expected_amps
+        self._min_device_current_lsb = self._calculate_min_current_lsb()
+        self._gain = None
+        self._auto_gain_enabled = False
+        self._voltage_range = None
+        self._current_lsb = None
+        self._power_lsb = None
+
+    def configure(self, voltage_range=RANGE_32V, gain=GAIN_AUTO,
+                  bus_adc=ADC_12BIT, shunt_adc=ADC_12BIT):
+        """Configure and calibrate how the INA219 will take measurements.
+
+        Arguments:
+        voltage_range -- The full scale voltage range, this is either 16V
+            or 32V represented by one of the following constants;
+            RANGE_16V, RANGE_32V (default).
+        gain -- The gain which controls the maximum range of the shunt
+            voltage represented by one of the following constants;
+            GAIN_1_40MV, GAIN_2_80MV, GAIN_4_160MV,
+            GAIN_8_320MV, GAIN_AUTO (default).
+        bus_adc -- The bus ADC resolution (9, 10, 11, or 12-bit) or
+            set the number of samples used when averaging results
+            represent by one of the following constants; ADC_9BIT,
+            ADC_10BIT, ADC_11BIT, ADC_12BIT (default),
+            ADC_2SAMP, ADC_4SAMP, ADC_8SAMP, ADC_16SAMP,
+            ADC_32SAMP, ADC_64SAMP, ADC_128SAMP
+        shunt_adc -- The shunt ADC resolution (9, 10, 11, or 12-bit) or
+            set the number of samples used when averaging results
+            represent by one of the following constants; ADC_9BIT,
+            ADC_10BIT, ADC_11BIT, ADC_12BIT (default),
+            ADC_2SAMP, ADC_4SAMP, ADC_8SAMP, ADC_16SAMP,
+            ADC_32SAMP, ADC_64SAMP, ADC_128SAMP
+        """
+        self.__validate_voltage_range(voltage_range)
+        self._voltage_range = voltage_range
+
+        if self._max_expected_amps is not None:
+            if gain == self.GAIN_AUTO:
+                self._auto_gain_enabled = True
+                self._gain = self._determine_gain(self._max_expected_amps)
+            else:
+                self._gain = gain
+        else:
+            if gain != self.GAIN_AUTO:
+                self._gain = gain
+            else:
+                self._auto_gain_enabled = True
+                self._gain = self.GAIN_1_40MV
+
+        self._calibrate(self.__GAIN_VOLTS[self._gain], self._max_expected_amps)
+        self._configure(voltage_range, self._gain, bus_adc, shunt_adc)
+
+    def voltage(self):
+        """Return the bus voltage in volts."""
+        value = self._voltage_register()
+        return float(value) * self.__BUS_MILLIVOLTS_LSB / 1000    
+
+    def supply_voltage(self):
+        """Return the bus supply voltage in volts.
+
+        This is the sum of the bus voltage and shunt voltage. A
+        DeviceRangeError exception is thrown if current overflow occurs.
+        """
+        return self.voltage() + (float(self.shunt_voltage()) / 1000)
+
+    def current(self):
+        """Return the bus current in milliamps.
+
+        A DeviceRangeError exception is thrown if current overflow occurs.
+        """
+        self._handle_current_overflow()
+        return self._current_register() * self._current_lsb * 1000
+
+    def power(self):
+        """Return the bus power consumption in milliwatts.
+
+        A DeviceRangeError exception is thrown if current overflow occurs.
+        """
+        self._handle_current_overflow()
+        return self._power_register() * self._power_lsb * 1000
+
+    def shunt_voltage(self):
+        """Return the shunt voltage in millivolts.
+
+        A DeviceRangeError exception is thrown if current overflow occurs.
+        """
+        self._handle_current_overflow()
+        return self._shunt_voltage_register() * self.__SHUNT_MILLIVOLTS_LSB
+
+    def sleep(self):
+        """Put the INA219 into power down mode."""
+        configuration = self._read_configuration()
+        self._configuration_register(configuration & 0xFFF8)
+
+    def wake(self):
+        """Wake the INA219 from power down mode."""
+        configuration = self._read_configuration()
+        self._configuration_register(configuration | 0x0007)
+        # 40us delay to recover from powerdown (p14 of spec)
+        time.sleep(0.00004)
+
+    def current_overflow(self):
+        """Return true if the sensor has detect current overflow.
+
+        In this case the current and power values are invalid.
+        """
+        return self._has_current_overflow()
+
+    def reset(self):
+        """Reset the INA219 to its default configuration."""
+        self._configuration_register(1 << self.__RST)
+
+    def is_conversion_ready(self):
+        """Check if conversion of a new reading has occured."""
+        cnvr = self._read_voltage_register() & self.__CNVR
+        return (cnvr == self.__CNVR)
+
+    def _handle_current_overflow(self):
+        if self._auto_gain_enabled:
+            while self._has_current_overflow():
+                self._increase_gain()
+        else:
+            if self._has_current_overflow():
+                raise DeviceRangeError(
+                    f"Current out of range for gain {self.__GAIN_VOLTS[self._gain]}"
+                )
+
+    def _determine_gain(self, max_expected_amps):
+        shunt_v = max_expected_amps * self._shunt_ohms
+        if shunt_v > self.__GAIN_VOLTS[3]:
+            raise ValueError(
+                'Expected amps %.2fA, out of range, use a lower '
+                'value shunt resistor' % max_expected_amps
+            )
+        gain = min(v for v in self.__GAIN_VOLTS if v > shunt_v)
+        return self.__GAIN_VOLTS.index(gain)
+
+    def _increase_gain(self):
+        gain = self._read_gain()
+        if gain < len(self.__GAIN_VOLTS) - 1:
+            gain = gain + 1
+            self._calibrate(self.__GAIN_VOLTS[gain])
+            self._configure_gain(gain)
+            # 1ms delay required for new configuration to take effect,
+            # otherwise invalid current/power readings can occur.
+            time.sleep(0.001)
+        else:
+            raise DeviceRangeError(
+                f"Current out of range for gain {self.__GAIN_VOLTS[gain]}V."
+                "Limit of device reached."
+            )
+
+    def _configure(self, voltage_range, gain, bus_adc, shunt_adc):
+        configuration = (
+            voltage_range << self.__BRNG | gain << self.__PG0 |
+            bus_adc << self.__BADC1 | shunt_adc << self.__SADC1 |
+            self.__CONT_SH_BUS)
+        self._configuration_register(configuration)
+
+    def _calibrate(self, shunt_volts_max, max_expected_amps=None):
+        max_possible_amps = shunt_volts_max / self._shunt_ohms
+
+        self._current_lsb = \
+            self._determine_current_lsb(max_expected_amps, max_possible_amps)
+
+        self._power_lsb = self._current_lsb * 20
+
+        calibration = trunc(self.__CALIBRATION_FACTOR /
+                            (self._current_lsb * self._shunt_ohms))
+        self._calibration_register(calibration)
+
+    def _determine_current_lsb(self, max_expected_amps, max_possible_amps):
+        if max_expected_amps is not None:
+            if max_expected_amps > round(max_possible_amps, 3):
+                raise ValueError(
+                    'Expected current %.3fA is greater '
+                    'than max possible current %.3fA' %
+                    (max_expected_amps, max_possible_amps)
+                )
+            if max_expected_amps < max_possible_amps:
+                current_lsb = max_expected_amps / self.__CURRENT_LSB_FACTOR
+            else:
+                current_lsb = max_possible_amps / self.__CURRENT_LSB_FACTOR
+        else:
+            current_lsb = max_possible_amps / self.__CURRENT_LSB_FACTOR
+
+        if current_lsb < self._min_device_current_lsb:
+            current_lsb = self._min_device_current_lsb
+        return current_lsb
+
+    def _configuration_register(self, register_value):
+        register_value = register_value.to_bytes(2, byteorder="little")
+        self.__write_register(self.__REG_CONFIG, register_value)
+
+    def _read_configuration(self):
+        register_value = self.__read_register(self.__REG_CONFIG)
+        return int.from_bytes(register_value, byteorder="little")
+
+    def _calculate_min_current_lsb(self):
+        return self.__CALIBRATION_FACTOR / \
+            (self._shunt_ohms * self.__MAX_CALIBRATION_VALUE)
+
+    def _read_gain(self):
+        configuration = self._read_configuration()
+        gain = (configuration & 0x1800) >> self.__PG0
+        return gain
+
+    def _configure_gain(self, gain):
+        configuration = self._read_configuration()
+        configuration = configuration & 0xE7FF
+        self._configuration_register(configuration | (gain << self.__PG0))
+        self._gain = gain
+
+    def _calibration_register(self, register_value):
+        register_value = register_value.to_bytes(2, byteorder="little")
+        self.__write_register(self.__REG_CALIBRATION, register_value)
+
+    def _has_current_overflow(self):
+        ovf = self._read_voltage_register() & self.__OVF
+        return (ovf == 1)
+
+    def _voltage_register(self):
+        register_value = self._read_voltage_register()
+        return register_value >> 3
+
+    def _read_voltage_register(self):
+        register_value = self.__read_register(self.__REG_BUSVOLTAGE)
+        return int.from_bytes(register_value, byteorder="little")
+
+    def _current_register(self):
+        register_value = self.__read_register(self.__REG_CURRENT)
+        return int.from_bytes(register_value, byteorder="little", signed=True)
+
+    def _shunt_voltage_register(self):
+        register_value = self.__read_register(self.__REG_SHUNTVOLTAGE)
+        return int.from_bytes(register_value, byteorder="little", signed=True)
+
+    def _power_register(self):
+        register_value = self.__read_register(self.__REG_POWER)
+        return int.from_bytes(register_value, byteorder="little")
+
+    def __validate_voltage_range(self, voltage_range):
+        if voltage_range > len(self.__BUS_RANGE) - 1:
+            raise ValueError(
+                'Invalid voltage range, must be one of: RANGE_16V, RANGE_32V'
+            )
+
+    def __write_register(self, register, register_value):
+        self._i2c.write_word(register, int.from_bytes(register_value, byteorder="big"))
+
+    def __read_register(self, register):
+        return self._i2c.read_word(register).to_bytes(2, byteorder="big")
+
+
+class DeviceRangeError(GPIOZeroError, ValueError):
+    """Error raised when input is out of range for the device."""

--- a/gpiozero/i2c_devices.py
+++ b/gpiozero/i2c_devices.py
@@ -1,0 +1,47 @@
+# vim: set fileencoding=utf-8:
+#
+# GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
+#
+# Copyright (c) 2016-2021 Dave Jones <dave@waveform.org.uk>
+# Copyright (c) 2020 Grzegorz Szymaszek <gszymaszek@short.pl>
+# Copyright (c) 2016-2019 Andrew Scheller <github@loowis.durge.org>
+# Copyright (c) 2016-2018 Ben Nuttall <ben@bennuttall.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .devices import Device
+from .exc import DeviceClosed, GPIOZeroError
+
+
+class I2CDevice(Device):
+    """
+    Extends :class:`Device`. Represents a device that communicates via the I2C
+    protocol.
+
+    See :ref:`i2c_args` for information on the keyword arguments that can be
+    specified with the constructor.
+    """
+
+    def __init__(self, **i2c_args):
+        self._i2c = None
+        super().__init__(pin_factory=i2c_args.pop("pin_factory", None))
+        self._i2c = self.pin_factory.i2c(**i2c_args)
+
+    def close(self):
+        if getattr(self, "_i2c", None):
+            self._i2c.close()
+            self._i2c = None
+        super().close()
+
+    @property
+    def closed(self):
+        return self._i2c is None
+
+    def __repr__(self):
+        try:
+            self._check_open()
+            return "<gpiozero.{self.__class__.__name__} object using " "{self._i2c!r}>".format(
+                self=self
+            )
+        except DeviceClosed:
+            return "<gpiozero.{self.__class__.__name__} object " "closed>".format(self=self)

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -769,3 +769,43 @@ class SPI(Device):
         limit the rate would simply slow them down to the point of being
         useless).
         """)
+
+
+class I2C(Device):
+    """
+    Abstract interface for `Inter-Integrated Circuit`_ (I2C)
+    implementations. Descendents *may* override the following methods, if applicable:
+
+    * :meth:`read_byte`
+    * :meth:`write_byte`
+    * :meth:`read_word`
+    * :meth:`write_word`
+    """
+
+    def read_byte(self, register):
+        """
+        Read 8 bits of data from the I2C device at the register with the address
+        *register*, returning them as a byte.
+        """
+        raise NotImplementedError
+
+    def write_byte(self, register, data):
+        """
+        Write *data* with a length of 8 bits to the I2C device at the register
+        with the address *register*.
+        """
+        raise NotImplementedError
+
+    def read_word(self, register):
+        """
+        Read 16 bits of data from the I2C device at the register with the address
+        *register*, returning them as two bytes.
+        """
+        raise NotImplementedError
+
+    def write_word(self, register, data):
+        """
+        Write *data* with a length of 16 bits to the I2C device at the register
+        with the address *register*.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Hi, all!

I needed I2C support for Remote GPIO so I added some bits and pieces to get it working. I tried to keep it as close to the SPI implementation as possible by pretty much copying everything.

This only includes a PiGPIOHardwareI2C implementation for now. I also did not add any additional documentation (except the copied docstrings).
For now I only added the `i2c_read_byte_data` , `i2c_read_word_data` , `i2c_write_byte_data` and `i2c_write_word_data` to read/write single bytes/words. This might not be the best solution, but worked for me.

I can work on this further for a bit, if this implementation is wanted. But I wanted to check first before I put more hours in.


As I was adding I2C to communicate with a INA219, I also added this as a new I2C device. This implementation is entirely stolen from [chrisb2's pi_ina219](https://github.com/chrisb2/pi_ina219). It has MIT license, but I'm not sure how to attribute him correctly or if I should add his MIT license somewhere?