### PR TITLE
Support setting custom active_state for InputDevice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,7 @@ See the `contributors page`_ on GitHub for more info.
 .. _Martchus: https://github.com/gpiozero/gpiozero/commits?author=Martchus
 .. _Martin O'Hanlon: https://github.com/martinohanlon/commits?author=martinohanlon
 .. _Mike Kazantsev: https://github.com/gpiozero/gpiozero/commits?author=mk-fg
+.. _Mischa Krüger: https://github.com/gpiozero/gpiozero/commits?author=Makman2
 .. _Paulo Mateus: https://github.com/gpiozero/gpiozero/commits?author=SrMouraSilva
 .. _Phil Howard: https://github.com/gpiozero/gpiozero/commits?author=Gadgetoid
 .. _Philippe Muller: https://github.com/gpiozero/gpiozero/commits?author=pmuller

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -40,7 +40,7 @@ class InputDevice(GPIODevice):
     Represents a generic GPIO input device.
 
     This class extends :class:`GPIODevice` to add facilities common to GPIO
-    input devices.  The constructor adds the optional *pull_up* parameter to
+    input devices. The constructor adds the optional *pull_up* parameter to
     specify how the pin should be pulled by the internal resistors. The
     :attr:`is_active` property is adjusted accordingly so that :data:`True`
     still means active regardless of the *pull_up* setting.
@@ -65,9 +65,11 @@ class InputDevice(GPIODevice):
         pin is ``HIGH``. If :data:`False`, the input polarity is reversed: when
         the hardware pin state is ``HIGH``, the software pin state is ``LOW``.
         Use this parameter to set the active state of the underlying pin when
-        configuring it as not pulled (when *pull_up* is :data:`None`). When
-        *pull_up* is :data:`True` or :data:`False`, the active state is
-        automatically set to the proper value.
+        configuring it as not pulled (when *pull_up* is :data:`None`) or when
+        you deliberately want to override what is considered the active state.
+        When *pull_up* is :data:`True` or :data:`False` and this parameter is
+        :data:`None`, the active state is by default set to :data:`False` and
+        :data:`True` respectively.
 
     :type pin_factory: Factory or None
     :param pin_factory:
@@ -93,11 +95,8 @@ class InputDevice(GPIODevice):
                     f'"active_state" is not defined')
             self._active_state = bool(active_state)
         else:
-            if active_state is not None:
-                raise PinInvalidState(
-                    f'Pin {self.pin.info.name} is not floating, but '
-                    f'"active_state" is not None')
-            self._active_state = False if pull_up else True
+            self._active_state = not pull_up if active_state is None else bool(active_state)
+
         self._inactive_state = not self._active_state
 
     @property
@@ -357,6 +356,12 @@ class Button(HoldMixin, DigitalInputDevice):
     pin. Alternatively, connect one side of the button to the 3V3 pin, and the
     other to any GPIO pin, then set *pull_up* to :data:`False` in the
     :class:`Button` constructor.
+
+    The defaults are tuned to normally-open buttons and switches (i.e. switch
+    contact shorts when pressed, and is open circuit when released). If you have
+    a normally-closed button (switch contact opens when pressed, but shorts when
+    not pressed), you can additionally adjust *active_state* to the same value
+    as *pull_up*.
 
     The following example will print a line of text when the button is pushed::
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -86,10 +86,31 @@ def test_input_invalid_pull_up(mock_factory):
         InputDevice(4, pull_up=None)
     assert str(exc.value) == 'Pin GPIO4 is defined as floating, but "active_state" is not defined'
 
-def test_input_invalid_active_state(mock_factory):
-    with pytest.raises(PinInvalidState) as exc:
-        InputDevice(4, active_state=True)
-    assert str(exc.value) == 'Pin GPIO4 is not floating, but "active_state" is not None'
+@pytest.mark.parametrize('pull_up,active_state,active_if_driven_high', [
+    (False, False, False),
+    (False, True, True),
+    (True, False, False),
+    (True, True, True),
+])
+def test_input_pull_up_down_with_non_default_active_state(pull_up, active_state, active_if_driven_high, mock_factory):
+    pin = mock_factory.pin(4)
+    device = InputDevice(4, pull_up=pull_up, active_state=active_state)
+    pin.drive_high()
+    assert device.is_active == active_if_driven_high
+    pin.drive_low()
+    assert device.is_active != active_if_driven_high
+
+@pytest.mark.parametrize('pull_up,active_if_driven_high', [
+    (False, True),
+    (True, False),
+])
+def test_input_pull_up_down_with_default_active_state(pull_up, active_if_driven_high, mock_factory):
+    pin = mock_factory.pin(4)
+    device = InputDevice(4, pull_up=pull_up)
+    pin.drive_high()
+    assert device.is_active == active_if_driven_high
+    pin.drive_low()
+    assert device.is_active != active_if_driven_high
 
 def test_input_event_activated(mock_factory):
     event = Event()


### PR DESCRIPTION
I hit the same limitation as described in #921. I use normally-closed switches for my experimental setup and needed to change the `active_state` parameter of `Button` to something else while using an internal pull-up or pull-down resistor to avoid soldering something and keep the experimental setup simple.

As [I commented in the issue](https://github.com/gpiozero/gpiozero/issues/921#issuecomment-1783804969), I went with following approach from the possibilities proposed by the original author of the issue @pmlk:

> Only when active_state is None should active_state be set automatically based on pull_up.

I left the other suggestion (which I think would be useful too), because it can be discussed separately and done in another PR:

> When both active_state is None and pull_up is None ("floating"), set active_state=True as a sensible default, rather than throwing an exception.

Please refer to my other reasonings in my [above mentioned comment](https://github.com/gpiozero/gpiozero/issues/921#issuecomment-1783804969). I am now lazy to copy them here :stuck_out_tongue: 

- [x] I read the [contributing guide](https://gpiozero.readthedocs.io/en/stable/contributing.html)
- [x] Unit tests added
- [x] Docs adjusted

Unit tests execute successfully skipping the real-pin tests.

I hope I have read everything correctly under the [contributing page](https://gpiozero.readthedocs.io/en/stable/contributing.html).