### PR TITLE
move pytest fixtures to own module - closes #1087

### DIFF
--- a/docs/api_fixtures.rst
+++ b/docs/api_fixtures.rst
@@ -1,0 +1,28 @@
+.. GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
+..
+.. SPDX-License-Identifier: BSD-3-Clause
+
+=====================
+API - pytest Fixtures
+=====================
+
+.. module:: gpiozero.testing.fixtures
+
+GPIO Zero includes fixtures for use with pytest which ensure that changes to
+:attr:`Device.pin_factory` are correctly reset after and between tests.
+
+These fixtures are the preferred method of using
+:class:`~gpiozero.pins.mock.MockFactory` and its descendents.
+
+They can be imported directly in your test or via your conftest.py either 
+individually or all together using:
+
+.. code-block:: python
+
+    from gpiozero.testing import *
+
+.. automodule:: gpiozero.testing.fixtures
+    :members:
+
+See :doc:`api_pins` for more details on the behaviour of
+:class:`~gpiozero.pins.mock.MockFactory` 

--- a/docs/api_pins.rst
+++ b/docs/api_pins.rst
@@ -195,6 +195,13 @@ Like the :envvar:`GPIOZERO_PIN_FACTORY` value, these can be exported from your
 Mock pins
 =========
 
+.. note::
+    While you **can** directly use the :class:`~gpiozero.pins.mock.MockFactory`
+    as detailled below, it is generally both easier and safer to make use of the
+    pre-prepared fixtures such as :func:`~gpiozero.testing.mock_factory`. See 
+    :doc:`api_fixtures` for more details.
+
+
 There's also a :class:`~gpiozero.pins.mock.MockFactory` which generates entirely
 fake pins. This was originally intended for GPIO Zero developers who wish to
 write tests for devices without having to have the physical device wired in to

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Table of Contents
     api_tones
     api_info
     api_pins
+    api_fixtures
     api_exc
     changelog
     license

--- a/gpiozero/testing/__init__.py
+++ b/gpiozero/testing/__init__.py
@@ -1,0 +1,3 @@
+from .fixtures import no_default_factory, mock_factory, pwm
+
+__ALL__ = ['no_default_factory', 'mock_factory', 'pwm']

--- a/gpiozero/testing/fixtures.py
+++ b/gpiozero/testing/fixtures.py
@@ -1,0 +1,55 @@
+import pytest
+from ..devices import Device
+from ..pins.mock import MockFactory, MockPWMPin
+
+@pytest.fixture()
+def no_default_factory(request):
+    """
+    pytest fixture which temporarily sets the default pin factory to `None`
+    and reverts the change at the end of the test run.
+    """
+    save_pin_factory = Device.pin_factory
+    Device.pin_factory = None
+    try:
+        yield None
+    finally:
+        Device.pin_factory = save_pin_factory
+
+@pytest.fixture(scope='function')
+def mock_factory(request):
+    """
+    pytest fixture which provides a mock pin factory for executing tests
+    without connected hardware. Ensures that the factory is **correctly
+    reset** between tests and in case of test failure.
+
+    Usage example:
+
+    .. code-block:: python
+
+        from gpiozero.testing import mock_factory
+
+        test_mockedpin(mock_factory)
+            pin16 = mock_factory.pin(16)
+            ...
+
+    """
+    save_factory = Device.pin_factory
+    Device.pin_factory = MockFactory()
+    try:
+        yield Device.pin_factory
+        # This reset() may seem redundant given we're re-constructing the
+        # factory for each function that requires it but MockFactory (via
+        # LocalFactory) stores some info at the class level which reset()
+        # clears.
+    finally:
+        if Device.pin_factory is not None:
+            Device.pin_factory.reset()
+        Device.pin_factory = save_factory
+
+@pytest.fixture()
+def pwm(request, mock_factory):
+    """
+    pytest fixture which extends :func:`mock_factory`. Default
+    :attr:`pin_class` is set to `MockPWMPin`
+    """
+    mock_factory.pin_class = MockPWMPin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys
-import pytest
 import warnings
 from threading import Event, Thread
 
-from gpiozero import Device
-from gpiozero.pins.mock import MockFactory, MockPWMPin
-
+# Safe to import * as we are specifically defining __ALL__ in testing/__init__.py
+# This makes fixtures defined in testing available as if they were defined here.
+from gpiozero.testing import *
 
 # NOTE: Work-around for python versions <3.4: in these versions the
 # resetwarnings function in the warnings module doesn't do much (or doesn't do
@@ -24,34 +23,6 @@ from gpiozero.pins.mock import MockFactory, MockPWMPin
 # catch_warnings()
 if sys.version_info[:2] < (3, 4):
     warnings.simplefilter('always')
-
-@pytest.fixture()
-def no_default_factory(request):
-    save_pin_factory = Device.pin_factory
-    Device.pin_factory = None
-    try:
-        yield None
-    finally:
-        Device.pin_factory = save_pin_factory
-
-@pytest.fixture(scope='function')
-def mock_factory(request):
-    save_factory = Device.pin_factory
-    Device.pin_factory = MockFactory()
-    try:
-        yield Device.pin_factory
-        # This reset() may seem redundant given we're re-constructing the
-        # factory for each function that requires it but MockFactory (via
-        # LocalFactory) stores some info at the class level which reset()
-        # clears.
-    finally:
-        if Device.pin_factory is not None:
-            Device.pin_factory.reset()
-        Device.pin_factory = save_factory
-
-@pytest.fixture()
-def pwm(request, mock_factory):
-    mock_factory.pin_class = MockPWMPin
 
 class ThreadedTest(Thread):
     def __init__(self, test_fn, *args, **kwargs):


### PR DESCRIPTION
Move pytest fixtures defined in tests/conftest.py to a module in the main source.
This makes them available for others to use via from gpiozero.testing import ...

@lurch: This is the replacement for #1107 with all commits squashed and the changes to the development internals removed.