### PR TITLE
Remove contributing hurdles - resolves #1109

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Editor detritus
 *.vim
 *.swp
+.vscode
+*.code-workspace
 tags
 
 # Packaging detritus

--- a/scripts/previewer
+++ b/scripts/previewer
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 


### PR DESCRIPTION
Updates to:

- `.gitignore` to support using venv virtual environments and vscode as editor
- `test.yml`github action to trigger on all branches - so it can be used for regression by all contributors on each push in their forks
- `previewer` to respect path resolution order for finding the prefered python version (e.g. in a venv)

While making these minor changes is not a big deal after forking, they need to be excluded from any pull requests - leading to more complicated rebasing before raising a PR and limited testing possible after rebasing. 