### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-22.04
             python: "3.11"
             experimental: false
+          - os: ubuntu-22.04
+            python: "3.12"
+            experimental: false
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
     - name: Run tests
       run: |
         pytest -v -k 'not test_real_pins.py'
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Editor detritus
 *.vim
 *.swp
+.vscode
+*.code-workspace
 tags
 
 # Packaging detritus

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -140,7 +140,7 @@ no longer supported (in practice, this means Python 2.7 is no longer
 supported). If your code is not compatible with Python 3, you should follow the
 `porting guide`_ in the `Python documentation`_.
 
-As of GPIO Zero 2.0, the lowest supported Python version will be 3.5. This base
+Currently, the lowest supported Python version is be 3.9. This base
 version may advance with minor releases, but we will make a reasonable best
 effort not to break compatibility with old Python 3.x versions, and to ensure
 that GPIO Zero can run on the version of Python in Debian oldstable at the

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -301,10 +301,6 @@ class Device(ValuesMixin, GPIOBase):
             # entry-point. Try with name verbatim first. If that fails, attempt
             # with the lower-cased name (this ensures compatibility names work
             # but we're still case insensitive for all factories)
-            with warnings.catch_warnings():
-                # The dict interface of entry_points is deprecated ... already
-                # and this deprecation is for us to worry about, not our users
-                warnings.simplefilter('ignore', category=DeprecationWarning)
             for ep in PinFactory_entry_points:
                 if ep.name == name:
                     return ep.load()()

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -16,7 +16,6 @@ import warnings
 from collections import namedtuple
 from itertools import chain
 from types import FunctionType
-from importlib.metadata import entry_points
 
 from .threads import _threads_shutdown
 from .mixins import (
@@ -34,6 +33,8 @@ from .exc import (
     NativePinFactoryFallback,
     PinFactoryFallback,
 )
+
+from .ep import PinFactory_entry_points
 
 from .compat import frozendict
 
@@ -304,11 +305,10 @@ class Device(ValuesMixin, GPIOBase):
                 # The dict interface of entry_points is deprecated ... already
                 # and this deprecation is for us to worry about, not our users
                 warnings.simplefilter('ignore', category=DeprecationWarning)
-                group = entry_points(group='gpiozero_pin_factories')
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name:
                     return ep.load()()
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name.lower():
                     return ep.load()()
             raise BadPinFactory(f'Unable to find pin factory {name!r}')

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -304,7 +304,7 @@ class Device(ValuesMixin, GPIOBase):
                 # The dict interface of entry_points is deprecated ... already
                 # and this deprecation is for us to worry about, not our users
                 warnings.simplefilter('ignore', category=DeprecationWarning)
-                group = entry_points()['gpiozero_pin_factories']
+                group = entry_points(group='gpiozero_pin_factories')
             for ep in group:
                 if ep.name == name:
                     return ep.load()()

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -15,3 +15,8 @@ try: #dict interface deprecated in Python 3.12
     PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')
 except TypeError: #selectable entrypoints only available from Python 3.10
     PinFactory_entry_points = entry_points()['gpiozero_pin_factories']
+
+try: #dict interface deprecated in Python 3.12
+    MockPinClass_entry_points = entry_points(group='gpiozero_mock_pin_classes')
+except TypeError: #selectable entrypoints only available from Python 3.10
+    MockPinClass_entry_points = entry_points()['gpiozero_mock_pin_classes']

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -1,0 +1,14 @@
+"""
+Provides access to the gpiozero entry points:
+
+.. code-block:: python
+    from gpiozero.ep import PinFactory_entry_points
+    
+    for ep in PinFactory_entry_points:
+        ...
+
+"""
+
+from importlib.metadata import entry_points
+
+PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -11,12 +11,13 @@ Provides access to the gpiozero entry points:
 
 from importlib.metadata import entry_points
 
-try: #dict interface deprecated in Python 3.12
-    PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')
-except TypeError: #selectable entrypoints only available from Python 3.10
-    PinFactory_entry_points = entry_points()['gpiozero_pin_factories']
+#prefix _ will stop this being imported via from ep import * if anyone tries
+def _get_entry_points(group): 
+    try: #dict interface deprecated in Python 3.12
+        _entry_points = entry_points(group=group)
+    except TypeError: #selectable entrypoints only available from Python 3.10
+        _entry_points = entry_points()[group]
+    return _entry_points    
 
-try: #dict interface deprecated in Python 3.12
-    MockPinClass_entry_points = entry_points(group='gpiozero_mock_pin_classes')
-except TypeError: #selectable entrypoints only available from Python 3.10
-    MockPinClass_entry_points = entry_points()['gpiozero_mock_pin_classes']
+PinFactory_entry_points = _get_entry_points(group='gpiozero_pin_factories')
+MockPinClass_entry_points = _get_entry_points(group='gpiozero_mock_pin_classes')

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -11,4 +11,7 @@ Provides access to the gpiozero entry points:
 
 from importlib.metadata import entry_points
 
-PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')
+try: #dict interface deprecated in Python 3.12
+    PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')
+except TypeError: #selectable entrypoints only available from Python 3.10
+    PinFactory_entry_points = entry_points()['gpiozero_pin_factories']

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -15,8 +15,3 @@ try: #dict interface deprecated in Python 3.12
     PinFactory_entry_points = entry_points(group='gpiozero_pin_factories')
 except TypeError: #selectable entrypoints only available from Python 3.10
     PinFactory_entry_points = entry_points()['gpiozero_pin_factories']
-
-try: #dict interface deprecated in Python 3.12
-    MockPinClass_entry_points = entry_points(group='gpiozero_mock_pin_classes')
-except TypeError: #selectable entrypoints only available from Python 3.10
-    MockPinClass_entry_points = entry_points()['gpiozero_mock_pin_classes']

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -592,7 +592,10 @@ class TimeOfDay(PolledInternalDevice):
         midnight), then this returns :data:`1` when the current time is
         greater than :attr:`start_time` or less than :attr:`end_time`.
         """
-        now = datetime.utcnow().time() if self.utc else datetime.now().time()
+        if self.utc:
+            now = datetime.utcnow().time()
+        else:
+            now = datetime.now().time()
         if self.start_time < self.end_time:
             return int(self.start_time <= now <= self.end_time)
         else:

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -592,8 +592,20 @@ class TimeOfDay(PolledInternalDevice):
         midnight), then this returns :data:`1` when the current time is
         greater than :attr:`start_time` or less than :attr:`end_time`.
         """
+        # utcnow() raises a DeprecationWarning from Python 3.12 onwards.
+        #
+        # Doing anything other than filtering this is potentially dangerous
+        # and we really should look to update TimeOfDay to offer a TimeZone aware
+        # interface, raise DeprecationWarnings ourselves for those using the naive
+        # options, and then later remove the naive options as they provide hobby
+        # programmers with a high-potential source of error. Adding a timezone-aware
+        # recipe or two would deifnitely be a good idea when doing this.
+        #
+        # See Issue #1111
         if self.utc:
-            now = datetime.utcnow().time()
+            with warnings.catch_warnings(): #NOT Thread-Safe, but in use elsewhere.
+                warnings.simplefilter(action='ignore', category=DeprecationWarning)
+                now = datetime.utcnow().time()
         else:
             now = datetime.now().time()
         if self.start_time < self.end_time:

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -464,6 +464,8 @@ class MockFactory(PiFactory):
             pin_class = pin_class.decode('ascii')
         if isinstance(pin_class, str):
             group = entry_points()['gpiozero_mock_pin_classes']
+            #TODO BUG this fails on python 3.9 with
+            # TypeError: tuple indices must be integers or slices, not str
             pin_class = group[pin_class.lower()].load()
         if not issubclass(pin_class, MockPin):
             raise ValueError(f'invalid mock pin_class: {pin_class!r}')

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -15,8 +15,6 @@ from threading import Thread, Event
 from math import isclose
 from importlib.metadata import entry_points
 
-from gpiozero.ep import MockPinClass_entry_points
-
 from ..exc import (
     PinPWMUnsupported,
     PinSetInput,
@@ -465,7 +463,7 @@ class MockFactory(PiFactory):
         if isinstance(pin_class, bytes):
             pin_class = pin_class.decode('ascii')
         if isinstance(pin_class, str):
-            group = MockPinClass_entry_points
+            group = entry_points()['gpiozero_mock_pin_classes']
             pin_class = group[pin_class.lower()].load()
         if not issubclass(pin_class, MockPin):
             raise ValueError(f'invalid mock pin_class: {pin_class!r}')

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -15,6 +15,8 @@ from threading import Thread, Event
 from math import isclose
 from importlib.metadata import entry_points
 
+from gpiozero.ep import MockPinClass_entry_points
+
 from ..exc import (
     PinPWMUnsupported,
     PinSetInput,
@@ -463,7 +465,7 @@ class MockFactory(PiFactory):
         if isinstance(pin_class, bytes):
             pin_class = pin_class.decode('ascii')
         if isinstance(pin_class, str):
-            group = entry_points()['gpiozero_mock_pin_classes']
+            group = MockPinClass_entry_points
             #TODO BUG this fails on python 3.9 with
             # TypeError: tuple indices must be integers or slices, not str
             pin_class = group[pin_class.lower()].load()

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -15,6 +15,8 @@ from threading import Thread, Event
 from math import isclose
 from importlib.metadata import entry_points
 
+from gpiozero.ep import MockPinClass_entry_points
+
 from ..exc import (
     PinPWMUnsupported,
     PinSetInput,
@@ -463,7 +465,7 @@ class MockFactory(PiFactory):
         if isinstance(pin_class, bytes):
             pin_class = pin_class.decode('ascii')
         if isinstance(pin_class, str):
-            group = entry_points()['gpiozero_mock_pin_classes']
+            group = MockPinClass_entry_points
             pin_class = group[pin_class.lower()].load()
         if not issubclass(pin_class, MockPin):
             raise ValueError(f'invalid mock pin_class: {pin_class!r}')

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -9,12 +9,7 @@ import os
 
 import pytest
 
-import sys
-
 from gpiozerocli.pinout import main
-
-
-python_version = sys.version_info.major + (sys.version_info.minor/100)
 
 
 def test_args_incorrect():

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -39,7 +39,7 @@ def test_help(capsys):
     out, err = capsys.readouterr()
     assert 'GPIO pin-out' in out
 
-@pytest.mark.xfail(condition=python_version>3.11, reason='Dict interface to entry_points() deprecated in 3.12', strict=True)
+# @pytest.mark.xfail(condition=python_version>3.11, reason='Dict interface to entry_points() deprecated in 3.12', strict=True)
 def test_execution(capsys, no_default_factory):
     os.environ['GPIOZERO_PIN_FACTORY'] = 'mock'
     assert main([]) == 0

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -9,7 +9,12 @@ import os
 
 import pytest
 
+import sys
+
 from gpiozerocli.pinout import main
+
+
+python_version = sys.version_info.major + (sys.version_info.minor/100)
 
 
 def test_args_incorrect():
@@ -34,6 +39,7 @@ def test_help(capsys):
     out, err = capsys.readouterr()
     assert 'GPIO pin-out' in out
 
+@pytest.mark.xfail(condition=python_version>3.11, reason='Dict interface to entry_points() deprecated in 3.12', strict=True)
 def test_execution(capsys, no_default_factory):
     os.environ['GPIOZERO_PIN_FACTORY'] = 'mock'
     assert main([]) == 0

--- a/tests/cli/test_pinout.py
+++ b/tests/cli/test_pinout.py
@@ -39,7 +39,6 @@ def test_help(capsys):
     out, err = capsys.readouterr()
     assert 'GPIO pin-out' in out
 
-# @pytest.mark.xfail(condition=python_version>3.11, reason='Dict interface to entry_points() deprecated in 3.12', strict=True)
 def test_execution(capsys, no_default_factory):
     os.environ['GPIOZERO_PIN_FACTORY'] = 'mock'
     assert main([]) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ from gpiozero.pins.mock import MockFactory, MockPWMPin
 if sys.version_info[:2] < (3, 4):
     warnings.simplefilter('always')
 
+# To allow @pytest.mark.xfail(condition=python_version<3.10) or similar
+python_version = sys.version_info.major + (sys.version_info.minor/100)
+
 @pytest.fixture()
 def no_default_factory(request):
     save_pin_factory = Device.pin_factory

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -15,8 +15,6 @@ import pytest
 from gpiozero import *
 from gpiozero.pins.mock import *
 
-from conftest import python_version
-
 def test_mock_pin_init(mock_factory):
     with pytest.raises(ValueError):
         Device.pin_factory.pin(60)

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -15,6 +15,7 @@ import pytest
 from gpiozero import *
 from gpiozero.pins.mock import *
 
+from conftest import python_version
 
 def test_mock_pin_init(mock_factory):
     with pytest.raises(ValueError):
@@ -237,6 +238,7 @@ def test_mock_charging_pin(mock_factory):
     sleep(0.1)
     assert pin.state == 1
 
+@pytest.mark.xfail(condition=python_version<3.10, reason='need to fix for 3.9', strict=True)
 def test_override_pin_class(no_default_factory):
     factory = MockFactory(pin_class='mocktriggerpin')
     #assert pin correctly instatiated

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -236,3 +236,6 @@ def test_mock_charging_pin(mock_factory):
     pin.function = 'input'
     sleep(0.1)
     assert pin.state == 1
+
+def test_override_pin_class(no_default_factory):
+    factory = MockFactory(pin_class='mocktriggerpin')

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -244,4 +244,8 @@ def test_override_pin_class(no_default_factory):
     pin16 = factory.pin(16)
     assert isinstance(pin16, MockTriggerPin)
 
-#Test incorrect capitalisation
+@pytest.mark.xfail(condition=python_version<3.10, reason='need to fix for 3.9', strict=True)
+def test_override_pin_class(no_default_factory):
+    factory = MockFactory(pin_class='MockTriggerPin')
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -241,6 +241,7 @@ def test_mock_charging_pin(mock_factory):
 @pytest.mark.xfail(condition=python_version<3.10, reason='need to fix for 3.9', strict=True)
 def test_override_pin_class(no_default_factory):
     factory = MockFactory(pin_class='mocktriggerpin')
-    #assert pin correctly instatiated
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)
 
 #Test incorrect capitalisation

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -238,13 +238,11 @@ def test_mock_charging_pin(mock_factory):
     sleep(0.1)
     assert pin.state == 1
 
-@pytest.mark.xfail(condition=python_version<3.10, reason='need to fix for 3.9', strict=True)
 def test_override_pin_class(no_default_factory):
     factory = MockFactory(pin_class='mocktriggerpin')
     pin16 = factory.pin(16)
     assert isinstance(pin16, MockTriggerPin)
 
-@pytest.mark.xfail(condition=python_version<3.10, reason='need to fix for 3.9', strict=True)
 def test_override_pin_class(no_default_factory):
     factory = MockFactory(pin_class='MockTriggerPin')
     pin16 = factory.pin(16)

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -243,7 +243,7 @@ def test_override_pin_class(no_default_factory):
     pin16 = factory.pin(16)
     assert isinstance(pin16, MockTriggerPin)
 
-def test_override_pin_class(no_default_factory):
+def test_override_pin_class_capitalisation(no_default_factory):
     factory = MockFactory(pin_class='MockTriggerPin')
     pin16 = factory.pin(16)
     assert isinstance(pin16, MockTriggerPin)

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -239,3 +239,6 @@ def test_mock_charging_pin(mock_factory):
 
 def test_override_pin_class(no_default_factory):
     factory = MockFactory(pin_class='mocktriggerpin')
+    #assert pin correctly instatiated
+
+#Test incorrect capitalisation

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -90,7 +90,6 @@ def test_pi_revision():
             with pytest.raises(PinUnknownPi):
                 PiBoardInfo.from_revision(0xfff)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info():
     r = pi_info('900011')
     assert r.model == 'B'
@@ -119,7 +118,6 @@ def test_pi_info():
     assert repr(r).startswith('PiBoardInfo(revision=')
     assert 'headers=...' in repr(r)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info_other_types():
     assert pi_info(b'9000f1') == pi_info(0x9000f1)
 

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -51,12 +51,12 @@ def local_hardware_spi_only(intf):
         pytest.skip("Test assumes LocalPiHardwareSPI descendant")
 
 
-with warnings.catch_warnings():
-    @pytest.fixture(
-        scope='module',
-        params=[ep.name for ep in PinFactory_entry_points])
-    def pin_factory_name(request):
-        return request.param
+
+@pytest.fixture(
+    scope='module',
+    params=[ep.name for ep in PinFactory_entry_points])
+def pin_factory_name(request):
+    return request.param
 
 
 @pytest.fixture()

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -53,8 +53,6 @@ def local_hardware_spi_only(intf):
 
 
 with warnings.catch_warnings():
-    # The dict interface of entry_points is deprecated ... already
-    warnings.simplefilter('ignore', category=DeprecationWarning)
     @pytest.fixture(
         scope='module',
         params=[ep.name for ep in PinFactory_entry_points])
@@ -65,9 +63,6 @@ with warnings.catch_warnings():
 @pytest.fixture()
 def pin_factory(request, pin_factory_name):
     try:
-        with warnings.catch_warnings():
-            # The dict interface of entry_points is deprecated ... already
-            warnings.simplefilter('ignore', category=DeprecationWarning)
         for ep in PinFactory_entry_points:
             if ep.name == pin_factory_name:
                 factory = ep.load()()
@@ -268,8 +263,6 @@ def test_explicit_factory(no_default_factory, pin_factory):
         assert device.pin_factory is pin_factory
         assert device.pin.info.name == TEST_PIN
 
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_envvar_factory(no_default_factory, pin_factory_name):
     os.environ['GPIOZERO_PIN_FACTORY'] = pin_factory_name
     assert Device.pin_factory is None

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -14,7 +14,6 @@ import warnings
 from time import time, sleep
 from math import isclose
 from unittest import mock
-from importlib.metadata import entry_points
 
 import pytest
 

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -19,6 +19,7 @@ from importlib.metadata import entry_points
 import pytest
 
 from gpiozero import *
+from gpiozero.ep import PinFactory_entry_points
 from gpiozero.pins.mock import MockConnectedPin, MockFactory, MockSPIDevice
 from gpiozero.pins.native import NativeFactory
 from gpiozero.pins.local import LocalPiFactory, LocalPiHardwareSPI
@@ -56,7 +57,7 @@ with warnings.catch_warnings():
     warnings.simplefilter('ignore', category=DeprecationWarning)
     @pytest.fixture(
         scope='module',
-        params=[ep.name for ep in entry_points()['gpiozero_pin_factories']])
+        params=[ep.name for ep in PinFactory_entry_points])
     def pin_factory_name(request):
         return request.param
 
@@ -67,8 +68,7 @@ def pin_factory(request, pin_factory_name):
         with warnings.catch_warnings():
             # The dict interface of entry_points is deprecated ... already
             warnings.simplefilter('ignore', category=DeprecationWarning)
-            eps = entry_points()['gpiozero_pin_factories']
-        for ep in eps:
+        for ep in PinFactory_entry_points:
             if ep.name == pin_factory_name:
                 factory = ep.load()()
                 break
@@ -280,8 +280,7 @@ def test_envvar_factory(no_default_factory, pin_factory_name):
             pin_factory_name=pin_factory_name, e=e))
     else:
         try:
-            group = entry_points()['gpiozero_pin_factories']
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == pin_factory_name:
                     factory_class = ep.load()
                     break


### PR DESCRIPTION
### Dict interface to `importlib.metadata.entry_points()` fully deprecated

 - Created a small module `ep.py` which gets the entry point groups in a fashion compatible with both 3.9 and 3.12
- Added test coverage for `pin_class=[str]` when instatiating `MockFactory`
(NOTE: This was also broken in 3.9, have fixed that bug as well)

### Deprecation of `datetime.utcnow()`

- Filtered out deprecation warning for now
- Raised #1111 for "proper" handing in the future
(NOTE: `warnings.catch_warnings()` is not threadsafe but already in use in a few places, so I felt OK adding it here as well)

### Various

- Added python3.12 to github action
- updated the docs to reflect that fact that 3.9 is the lowest version currently supports (based on the `test.yml` and `setup.cfg`)
- provided a `python_version` to `conftest.py` which provides major.minor as a `float` for use in e.g. `xfail`, assuming this wil have repeated usefulness in the future