### PR TITLE
Make TimeOfDay timezone aware - closes #1111

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,8 @@ jobs:
     - name: Run tests
       run: |
         pytest -v -k 'not test_real_pins.py' --cov
+
+    # This only runs if you have a codecov.io account set up and linked,
+    # otherwise it will fail silently
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        make develop
+        pip install -e .[test]
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -k 'not test_real_pins.py'
+        pytest -v -k 'not test_real_pins.py' --cov

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.vim
 *.swp
 tags
+# If you wish to contribute and use a different editor, please don't 
+# extend this list, or it will quickly get very long.
+# Instead create a '.gitignore-global' file in your home directory and 
+# run 'git config --global core.excludesfile ~/.gitignore-global'
 
 # Packaging detritus
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -13,7 +13,7 @@ import os
 import io
 import warnings
 import subprocess
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 from .devices import Device
 from .mixins import EventsMixin, event
@@ -489,8 +489,11 @@ class TimeOfDay(PolledInternalDevice):
     *start_time* and *end_time* (inclusive) which are :class:`~datetime.time`
     instances.
 
+    Note that *start_time* may be greater than *end_time*, indicating a time
+    period which crosses midnight.
+
     The following example turns on a lamp attached to an :class:`Energenie`
-    plug between 07:00AM and 08:00AM::
+    plug between 07:00AM and 08:00AM UTC::
 
         from gpiozero import TimeOfDay, Energenie
         from datetime import time
@@ -504,8 +507,35 @@ class TimeOfDay(PolledInternalDevice):
 
         pause()
 
-    Note that *start_time* may be greater than *end_time*, indicating a time
-    period which crosses midnight.
+    By default start and end times are timezone-aware UTC times. If you wish to
+    specify the time-zone for the start and/or end time you can do so when 
+    contructing the time, for example to switch on when it is office hours in 
+    both London and Los Angeles::
+
+        from gpiozero import TimeOfDay,
+        from datetime import time,
+        from zoneinfo import ZoneInfo
+
+        tz_LA = ZoneInfo('America/Los_Angeles')
+        tz_London = ZoneInfo('Europe/London')
+
+        officehours = TimeOfDay(time(8,30,tzinfo=tz_LA), time(18,00,tzinfo=tz_London))
+
+    If you would like to ignore timezones and use "local time" (whatever time
+    your Pi's internal clock says) then set `utc` to `False`. To
+    switch on during whatever your Pi thinks are local office hours::
+        
+        from gpiozero import TimeOfDay,
+        from datetime import time
+
+        officehours = TimeOfDay(time(8,30), time(18,00), utc=False)
+
+    .. note::
+        For backwards compatibility you can also select to use naive UTC times by
+        setting `utc` to `True` - this is no longer recommended,
+        instead you should leave `utc` set to `None` or explicity
+        specify `tzinfo=UTC` (`from datetime import UTC`) - both will give the
+        same result. 
 
     :param ~datetime.time start_time:
         The time from which the device will be considered active.
@@ -514,51 +544,97 @@ class TimeOfDay(PolledInternalDevice):
         The time after which the device will be considered inactive.
 
     :param bool utc:
-        If :data:`True` (the default), a naive UTC time will be used for the
-        comparison rather than a local time-zone reading.
+        If `None` (the default), UTC time will be used for the comparison. 
+        If `False` the local clock time will be use, ignoring the timezone. 
+        (If `True` a naive UTC time will be used - this is not recommended, 
+        see the note above)
 
     :type event_delay: float
     :param event_delay:
-        The number of seconds between file reads (defaults to 10 seconds).
+        The number of seconds between file reads (defaults to 5 seconds).
 
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
-    def __init__(self, start_time, end_time, *, utc=True, event_delay=5.0,
+
+    def __init__(self, start_time, end_time, *, utc=None, event_delay=5.0,
                  pin_factory=None):
-        self._start_time = None
-        self._end_time = None
-        self._utc = True
+    
+        utc_deprecation_warning = (
+        'Using utc=True is deprecated and scheduled for removal in a future version.'
+        ' Please use tz="UTC" or provide a Timezone-Aware start and end time'
+        )
+        if utc:
+            warnings.warn(utc_deprecation_warning, DeprecationWarning)
+
+        self._aware = utc is None
+        self._utc = utc
+
         super().__init__(event_delay=event_delay, pin_factory=pin_factory)
         try:
             self._start_time = self._validate_time(start_time)
             self._end_time = self._validate_time(end_time)
             if self.start_time == self.end_time:
                 raise ValueError('end_time cannot equal start_time')
-            self._utc = utc
             self._fire_events(self.pin_factory.ticks(), self.is_active)
         except:
             self.close()
             raise
 
     def __repr__(self):
+        reprname = f'gpiozero.{self.__class__.__name__} object'
+        if self.aware:
+            reprstart = f'{self.start_time.replace(tzinfo=None)} [{self.start_time.tzinfo}]'
+            reprend = f'{self.end_time.replace(tzinfo=None)} [{self.end_time.tzinfo}]'
+            reprtz = ''
+        else:
+            reprstart = f'{self.start_time}'
+            reprend = f'{self.end_time}'
+            reprtz = f'{(" local", " UTC")[self.utc]}'
         try:
             self._check_open()
-            return (
-                f'<gpiozero.{self.__class__.__name__} object active between '
-                f'{self.start_time} and {self.end_time} '
-                f'{("local", "UTC")[self.utc]}>')
+            return f'<{reprname} active between {reprstart} and {reprend}{reprtz}>'
         except DeviceClosed:
             return super().__repr__()
 
     def _validate_time(self, value):
-        if isinstance(value, datetime):
-            value = value.time()
-        if not isinstance(value, time):
-            raise ValueError(
+        # If we have a datetime or similar we only want the time.
+        # hasattr is faster than try-except if we usually expect try to fail - and
+        # we'll probably be getting a time more often than a datetime
+        if hasattr(value, 'timetz'): 
+            value = value.timetz()
+        
+        if not self.aware:
+            try:
+                assert value.tzinfo == None
+            except AttributeError:
+                True # Want to include this branch in coverage report
+                pass # pass is excluded from coverage in setup.cfg 
+            except AssertionError:
+                raise ValueError(
+                'utc must be None if start_time or end_time contain tzinfo')
+
+        # Using try-except to cope with cases where someone has used an object
+        # that offers comparison with time but is not a subclass of time.
+        # Not relying on time's current implementation that checks for timetuple()
+        # as this may change in the future
+        if self.aware:            
+            try: # We need to be able to replace tzinfo and compare to aware time
+                value.replace(tzinfo=timezone.utc) < time(1, tzinfo=timezone.utc)
+            except (AttributeError, TypeError):
+                raise ValueError(
                 'start_time and end_time must be a datetime, or time instance')
+        else:
+            try: # We need to be able to compare to naive time
+                value < time(1)
+            except TypeError:
+                raise ValueError(
+                'start_time and end_time must be a datetime, or time instance')
+            
+        if self.aware and value.tzinfo == None: # Default to UTC
+            value = value.replace(tzinfo=timezone.utc)
         return value
 
     @property
@@ -578,10 +654,19 @@ class TimeOfDay(PolledInternalDevice):
     @property
     def utc(self):
         """
-        If :data:`True`, use a naive UTC time reading for comparison instead of
-        a local timezone reading.
+        If `None` (the default), UTC time will be used for the comparison. 
+        If `False` the local clock time will be use, ignoring the timezone. 
+        (If `True` a naive UTC time will be used - this is not recommended, 
+        see the note above)
         """
         return self._utc
+    
+    @property
+    def aware(self):
+        """
+        Whether the comparison will be performed in a timezone-aware manner
+        """
+        return self._aware
 
     @property
     def value(self):
@@ -592,11 +677,28 @@ class TimeOfDay(PolledInternalDevice):
         midnight), then this returns :data:`1` when the current time is
         greater than :attr:`start_time` or less than :attr:`end_time`.
         """
-        now = datetime.utcnow().time() if self.utc else datetime.now().time()
-        if self.start_time < self.end_time:
-            return int(self.start_time <= now <= self.end_time)
+        if self.aware:
+            # Beware - most timezone implementations in zoneinfo are only aware
+            # for datetime, not time objects.
+            # Think about DST to understand why ...
+            # So we need to get the current offset for each timezone right now
+            # and update the tzinfo. Doing it this way means we can keep the
+            # comparison simple and consistent for both aware and naive situations
+            now = datetime.now(tz=timezone.utc)
+            start_offset = now.astimezone(self.start_time.tzinfo).utcoffset()
+            end_offset = now.astimezone(self.end_time.tzinfo).utcoffset()
+            timenow = now.timetz()
+            _start_time = self.start_time.replace(tzinfo=timezone(start_offset))
+            _end_time = self.end_time.replace(tzinfo=timezone(end_offset))
         else:
-            return int(not self.end_time < now < self.start_time)
+            timenow = datetime.utcnow().time() if self.utc else datetime.now(tz=None).time()
+            _start_time = self.start_time
+            _end_time = self.end_time
+
+        if _start_time < _end_time:
+            return int(_start_time <= timenow <= _end_time)
+        else:
+            return int(not _end_time < timenow < _start_time)
 
     when_activated = event(
         """

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -522,8 +522,8 @@ class TimeOfDay(PolledInternalDevice):
         officehours = TimeOfDay(time(8,30,tzinfo=tz_LA), time(18,00,tzinfo=tz_London))
 
     If you would like to ignore timezones and use "local time" (whatever time
-    your Pi's internal clock says) then set `utc` to `False`. To
-    switch on during whatever your Pi thinks are local office hours::
+    your Pi's clock says) then set `utc` to `False`. To switch on during whatever
+    your Pi thinks are local office hours::
         
         from gpiozero import TimeOfDay,
         from datetime import time

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -564,7 +564,8 @@ class TimeOfDay(PolledInternalDevice):
     
         utc_deprecation_warning = (
         'Using utc=True is deprecated and scheduled for removal in a future version.'
-        ' Please use tz="UTC" or provide a Timezone-Aware start and end time'
+        ' Start and end times will default to tzinfo=datetime.UTC unless you specify'
+        ' different tzinfo when defining them.'
         )
         if utc:
             warnings.warn(utc_deprecation_warning, DeprecationWarning)

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -586,7 +586,7 @@ class TimeOfDay(PolledInternalDevice):
 
     def __repr__(self):
         reprname = f'gpiozero.{self.__class__.__name__} object'
-        if self.aware:
+        if self.timezone_aware:
             reprstart = f'{self.start_time.replace(tzinfo=None)} [{self.start_time.tzinfo}]'
             reprend = f'{self.end_time.replace(tzinfo=None)} [{self.end_time.tzinfo}]'
             reprtz = ''
@@ -607,7 +607,7 @@ class TimeOfDay(PolledInternalDevice):
         if hasattr(value, 'timetz'): 
             value = value.timetz()
         
-        if not self.aware:
+        if not self.timezone_aware:
             try:
                 assert value.tzinfo == None
             except AttributeError:
@@ -621,7 +621,7 @@ class TimeOfDay(PolledInternalDevice):
         # that offers comparison with time but is not a subclass of time.
         # Not relying on time's current implementation that checks for timetuple()
         # as this may change in the future
-        if self.aware:            
+        if self.timezone_aware:            
             try: # We need to be able to replace tzinfo and compare to aware time
                 value.replace(tzinfo=timezone.utc) < time(1, tzinfo=timezone.utc)
             except (AttributeError, TypeError):
@@ -634,7 +634,7 @@ class TimeOfDay(PolledInternalDevice):
                 raise ValueError(
                 'start_time and end_time must be a datetime, or time instance')
             
-        if self.aware and value.tzinfo == None: # Default to UTC
+        if self.timezone_aware and value.tzinfo == None: # Default to UTC
             value = value.replace(tzinfo=timezone.utc)
         return value
 
@@ -663,7 +663,7 @@ class TimeOfDay(PolledInternalDevice):
         return self._utc
     
     @property
-    def aware(self):
+    def timezone_aware(self):
         """
         Whether the comparison will be performed in a timezone-aware manner
         """
@@ -678,7 +678,7 @@ class TimeOfDay(PolledInternalDevice):
         midnight), then this returns :data:`1` when the current time is
         greater than :attr:`start_time` or less than :attr:`end_time`.
         """
-        if self.aware:
+        if self.timezone_aware:
             # Beware - most timezone implementations in zoneinfo are only aware
             # for datetime, not time objects.
             # Think about DST to understand why ...

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -570,7 +570,7 @@ class TimeOfDay(PolledInternalDevice):
         if utc:
             warnings.warn(utc_deprecation_warning, DeprecationWarning)
 
-        self._aware = utc is None
+        self._tzaware = utc is None
         self._utc = utc
 
         super().__init__(event_delay=event_delay, pin_factory=pin_factory)
@@ -667,7 +667,7 @@ class TimeOfDay(PolledInternalDevice):
         """
         Whether the comparison will be performed in a timezone-aware manner
         """
-        return self._aware
+        return self._tzaware
 
     @property
     def value(self):

--- a/scripts/class_graph
+++ b/scripts/class_graph
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/scripts/previewer
+++ b/scripts/previewer
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,9 @@ gpiozero_mock_pin_classes =
     mocktriggerpin   = gpiozero.pins.mock:MockTriggerPin
 
 [tool:pytest]
-addopts = -rsx --cov --tb=short
+# addopts = -rsx --cov --tb=short
+# Uncomment the above line to provide basic coverage information in local runs
+# Comment out the above line to allow for debugging of tests (broken by --cov)
 testpaths = tests
 
 [coverage:run]

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -15,15 +15,19 @@ from posix import statvfs_result
 from subprocess import CalledProcessError
 from threading import Event
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from gpiozero import *
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 file_not_found = IOError(errno.ENOENT, 'File not found')
 bad_ping = CalledProcessError(1, 'returned non-zero exit status 1')
 
+utc = timezone.utc
+tz_LA = ZoneInfo('America/Los_Angeles')
+tz_London = ZoneInfo('Europe/London')
 
 def test_polled_event_delay(mock_factory):
     with TimeOfDay(time(7), time(8)) as tod:
@@ -47,6 +51,48 @@ def test_timeofday_bad_init(mock_factory):
         TimeOfDay(7.00, 8.00)
     with pytest.raises(ValueError):
         TimeOfDay(datetime(2019, 1, 24, 19), time(19))  # lurch edge case
+    with pytest.deprecated_call(match='utc=True'):
+        TimeOfDay(time(7), time(8), utc=True)
+    with pytest.raises(ValueError,
+            match = 'start_time and end_time must be a datetime, or time instance'):
+        TimeOfDay('7:00', '8:00', utc=True) # edge case
+
+@pytest.mark.parametrize(
+        'args',[
+            pytest.param(
+                (time(7, tzinfo=utc), time(8)),
+                id="startaware"
+                ),
+            pytest.param(
+                (time(7), time(8,tzinfo=utc)),
+                id='endaware'
+                ),
+            pytest.param(
+                (time(7, tzinfo=tz_LA), time(8)),
+                id='startZoneInfo'
+                ),
+            pytest.param(
+                (time(7), time(8,tzinfo=tz_LA)),
+                id='endZoneInfo'
+                ),
+            ]
+        )
+@pytest.mark.parametrize(
+        'kwargs',[
+            pytest.param(
+                {'utc':True},
+                id="utcTrue"
+                ),
+            pytest.param(
+                {'utc': False},
+                id='utcFalse'
+                ),
+            ]
+        )
+def test_TimeOfDay_timezoneawaremismatch(mock_factory, args, kwargs):
+    errormessage = 'utc must be None if start_time or end_time contain tzinfo'
+    with pytest.raises(ValueError, match=errormessage):
+        TimeOfDay(*args, **kwargs)
 
 def test_timeofday_init(mock_factory):
     TimeOfDay(time(7), time(8), utc=False)
@@ -58,10 +104,48 @@ def test_timeofday_init(mock_factory):
     TimeOfDay(time(6), time(18))
     TimeOfDay(time(18), time(6))
     TimeOfDay(datetime(2019, 1, 24, 19), time(19, 1))  # lurch edge case
+    TimeOfDay(time(8,30), time(18,00), utc=False) # Documented example
 
-def test_timeofday_value(mock_factory):
+
+@pytest.mark.parametrize(
+        ('args', 'kwargs', 'start', 'end', 'aware'),[
+            pytest.param(
+                (datetime(2024,2,1,18,00,tzinfo=tz_LA), datetime(2024,2,1,23,00,tzinfo=tz_LA)),
+                {},
+                time(18,00,tzinfo=tz_LA),
+                time(23,00,tzinfo=tz_LA),
+                True,
+                id="datetime"
+                ),
+            pytest.param(
+                (time(7, tzinfo=tz_LA), time(8)),
+                {},
+                time(7,00,tzinfo=tz_LA),
+                time(8, tzinfo=utc),
+                True,
+                id='mixed-default'
+                ),
+            pytest.param(
+                (time(7, tzinfo=None), time(8, tzinfo=None)),
+                {'utc':False},
+                time(7),
+                time(8),
+                False,
+                id='local-tzinfoexplicityNone'
+                ),
+            ]
+    )
+def test_TimeOfDay_init_timezone(mock_factory, args, kwargs, start, end, aware):
+    with TimeOfDay(*args, **kwargs) as tod:
+        assert tod.start_time == start
+        assert tod.start_time.tzinfo == start.tzinfo
+        assert tod.end_time == end
+        assert tod.end_time.tzinfo == end.tzinfo
+        assert tod.aware == aware
+
+def test_TimeOfDay_naivelocal(mock_factory):
     with TimeOfDay(time(7), time(8), utc=False) as tod:
-        assert repr(tod).startswith('<gpiozero.TimeOfDay object')
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 and 08:00:00 local>'
         assert tod.start_time == time(7)
         assert tod.end_time == time(8)
         assert not tod.utc
@@ -74,56 +158,148 @@ def test_timeofday_value(mock_factory):
             assert tod.is_active
             dt.now.return_value = datetime(2018, 1, 2, 8, 1, 0)
             assert not tod.is_active
+            assert all([call.kwargs['tz'] == None for call in dt.mock_calls if call[0]=='now'])
     assert repr(tod) == '<gpiozero.TimeOfDay object closed>'
 
+def test_TimeOfDay_defaultUTC(mock_factory):
     with TimeOfDay(time(1, 30), time(23, 30)) as tod:
-        assert tod.start_time == time(1, 30)
-        assert tod.end_time == time(23, 30)
-        assert tod.utc
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 01:30:00 [UTC] and 23:30:00 [UTC]>'
+        assert tod.start_time == time(1, 30, tzinfo=utc)
+        assert tod.end_time == time(23, 30, tzinfo=utc)
+        assert not tod.utc
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 1, 29, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 1, 29, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 1, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 1, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 12, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 12, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 31, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 31, 0, tzinfo=utc)
+            assert not tod.is_active
+            assert all([call.kwargs['tz'] == utc for call in dt.mock_calls if call[0]=='now'])
+
+def test_TimeOfDay_naiveutc(mock_factory):
+    with pytest.deprecated_call(match='utc=True'):
+        with TimeOfDay(time(7), time(8), utc=True) as tod:
+            assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 and 08:00:00 UTC>'
+            assert tod.start_time == time(7, tzinfo=None)
+            assert tod.end_time == time(8, tzinfo=None)
+            assert tod.utc == True
+            with mock.patch('gpiozero.internal_devices.datetime') as dt:
+                dt.utcnow.return_value = datetime(2018, 1, 1, 6, 59, 0)
+                assert not tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 1, 7, 0, 0)
+                assert tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 2, 8, 0, 0)
+                assert tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 2, 8, 1, 0)
+                assert not tod.is_active
+
+def test_TimeOfDay_tzgiven(mock_factory):
+    start = time(7, tzinfo=tz_LA)
+    end = time(8, tzinfo=tz_LA)
+    with TimeOfDay(start, end) as tod:
+        assert tod.aware == True
+        assert tod.start_time == start
+        assert tod.end_time == end
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 [America/Los_Angeles] and 08:00:00 [America/Los_Angeles]>'
+        with mock.patch('gpiozero.internal_devices.datetime') as dt:
+            # No DST
+            dt.now.return_value = datetime(2018, 1, 1, 7, 1, 0, tzinfo=utc) # 2017-12-31 23:01 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 14, 59, 59, tzinfo=utc) # 2018-01-01 06:59:59 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 15, 0, 0, tzinfo=utc) # 2018-01-01 07:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 16, 0, 0, tzinfo=utc) # 2018-01-01 08:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 16, 1, 0, tzinfo=utc) # 2018-01-01 08:01 [LA]
+            assert not tod.is_active
+            # DST
+            dt.now.return_value = datetime(2018, 8, 1, 7, 1, 0, tzinfo=utc) # 2018-08-01 00:01 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 13, 59, 59, tzinfo=utc) # 2018-08-01 06:59:59 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 14, 0, 0, tzinfo=utc) # 2018-08-01 07:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 15, 0, 0, tzinfo=utc) # 2018-08-01 08:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 15, 1, 0, tzinfo=utc) # 2018-08-01 08:01 [LA]
+            assert not tod.is_active
+            assert all([call.kwargs['tz'] == utc for call in dt.mock_calls if call[0]=='now'])
+
+def test_TimeOfDay_differentTZ(mock_factory):
+    with TimeOfDay(time(8,30,tzinfo=tz_LA), time(18,00,tzinfo=tz_London)) as tod:
+        assert tod.start_time == time(8,30) # LA not aware without date (DST)
+        assert tod.start_time.tzinfo == tz_LA
+        assert tod.end_time == time(18,00) # London not aware without date (DST)
+        assert tod.end_time.tzinfo == tz_London
+        assert tod.aware
+        with mock.patch('gpiozero.internal_devices.datetime') as dt:
+            # No DST
+            dt.now.return_value = datetime(2024,1,25,16,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,1,25,16,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,1,25,18,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,1,25,18,1, tzinfo=utc)
+            assert not tod.is_active
+            # LA DST
+            dt.now.return_value = datetime(2024,3,10,15,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,3,10,15,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,10,18,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,10,18,1, tzinfo=utc)
+            assert not tod.is_active
+            # Both DST
+            dt.now.return_value = datetime(2024,3,31,15,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,3,31,15,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,31,17,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,31,17,1, tzinfo=utc)
             assert not tod.is_active
 
+def test_TimeOfDay_activeovermidnight1(mock_factory):
     with TimeOfDay(time(23), time(1)) as tod:
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 22, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 22, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 1, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 1, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 1, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 1, 1, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 3, 12, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 3, 12, 0, 0, tzinfo=utc)
             assert not tod.is_active
 
+def test_TimeOfDay_activeovermidnight2(mock_factory):
     with TimeOfDay(time(6), time(5)) as tod:
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 30, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 6, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 6, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 18, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 18, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 1, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 30, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 6, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 6, 0, 0, tzinfo=utc)
             assert tod.is_active
 
 def test_polled_events(mock_factory):
@@ -132,17 +308,17 @@ def test_polled_events(mock_factory):
         activated = Event()
         deactivated = Event()
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 0, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 0, 0, 0, tzinfo=utc)
             tod._fire_events(tod.pin_factory.ticks(), tod.is_active)
             tod.when_activated = activated.set
             tod.when_deactivated = deactivated.set
             assert not activated.wait(0)
             assert not deactivated.wait(0)
-            dt.utcnow.return_value = datetime(2018, 1, 1, 7, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 7, 1, 0, tzinfo=utc)
             assert activated.wait(1)
             activated.clear()
             assert not deactivated.wait(0)
-            dt.utcnow.return_value = datetime(2018, 1, 1, 8, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 8, 1, 0, tzinfo=utc)
             assert deactivated.wait(1)
             assert not activated.wait(0)
             tod.when_activated = None

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -141,7 +141,7 @@ def test_TimeOfDay_init_timezone(mock_factory, args, kwargs, start, end, aware):
         assert tod.start_time.tzinfo == start.tzinfo
         assert tod.end_time == end
         assert tod.end_time.tzinfo == end.tzinfo
-        assert tod.aware == aware
+        assert tod.timezone_aware == aware
 
 def test_TimeOfDay_naivelocal(mock_factory):
     with TimeOfDay(time(7), time(8), utc=False) as tod:
@@ -201,7 +201,7 @@ def test_TimeOfDay_tzgiven(mock_factory):
     start = time(7, tzinfo=tz_LA)
     end = time(8, tzinfo=tz_LA)
     with TimeOfDay(start, end) as tod:
-        assert tod.aware == True
+        assert tod.timezone_aware == True
         assert tod.start_time == start
         assert tod.end_time == end
         assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 [America/Los_Angeles] and 08:00:00 [America/Los_Angeles]>'
@@ -236,7 +236,7 @@ def test_TimeOfDay_differentTZ(mock_factory):
         assert tod.start_time.tzinfo == tz_LA
         assert tod.end_time == time(18,00) # London not aware without date (DST)
         assert tod.end_time.tzinfo == tz_London
-        assert tod.aware
+        assert tod.timezone_aware
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
             # No DST
             dt.now.return_value = datetime(2024,1,25,16,29, tzinfo=utc)


### PR DESCRIPTION
## Background

`utcnow()` is deprecated in python3.12 to reduce the danger of naive utc times being incorrectly interpreted as local times. [see the warning in the docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow)

The current implementation uses a flag, `utc`, in the instance to track whether the start and end times are naive utc or local time. This flag defaults to `True`.

This leads to deprecation warnings being raised which can only be dealt with in a non-thread-safe manner and collides with the future assumptions that users will make based upon the above deprecation.

## Semantics of the change

I have tried to preserve the following semantics to ensure not only tehcnical but also logical backwards compatibility:
- default handling is for times to be treated as UTC if nothing else is specified
- `utc=False` is used for specifying that times are "local time"
- specifying `utc=True` will force a naive utc, raise a custom deprecation warning to better explain the situation and allow the official warning to propogate (providing the user with full context and avoiding threading issues)
- where a timezone is given which is not a fixed offset (e.g.: a location which may observe daylight saving time) the current time in the location today, right now is used for comparison


## Additional points for discussion

1. It could be valuable to implement a new flag `local` (default: `False`) while still initially preserving the behaviour of `utc`. Given that `utc` is in future primarily used to flag local time `TimeOfDay(time(7), time(8), local=True)` would be more obvious in its intentions than `TimeOfDay(time(7), time(8), utc=False)`. This would also allow for the utc flag to be moved to a less prominent place in the documentation, the arguments order and possibly fully deprecated in v3.0.
1. When providing a `datetime` instance as a start or end time the date is ignored and only the time element stored. This could be confusing, now that more use is made of the specifics of the start and end time objects (by leveraging their `tzinfo`). Any changes to this behaviour would significantly change the semantics of the function. Perhaps there is a way to allow for the user to decide whether they really mean "at this one specific point in time", or "at this time every day"? It may be worth formally documenting the possibility to provide a datetime object and highlighting this behaviour. (The ability to pass a datetime object is currently undocumented but tested).

## Additional changes included
- adjustments to the validation process should now allow for substitution of datetime.datetime and datetime.time objects with others which provide the required interfaces but may not officially subclass the standard objects.
- adjustments the development environment to provide for virtual environments and running the tests on changes to every branch should contributors use these. (the commits from #1122)

## Changes originally included but now removed from this PR based on comments
- fixes to the implementation of entry_points to ensure python3.12 compatibility. This effectively removes the need for #1112. Given that the deprecation of `utcnow`occurs in 3.12 it makes sense to include these changes here - otherwise testing in 3.12 will cause multiple tests to fail.

Closes #1111