### PR TITLE
ensure python3.7 compatibility - closes #1113

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,86 @@
+ARG DEBIAN=debian
+FROM debian:${DEBIAN}
+ARG PYVERSION=3
+
+# ---
+# Create the default user - vscode mounts workspace directory chowned to 1000:1000
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+&& useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+&& apt-get update \
+&& apt-get install -y sudo \
+&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+&& chmod 0440 /etc/sudoers.d/$USERNAME
+
+# ---
+# Install basic dev tools
+RUN apt update \
+&& apt install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    locales \
+    locales-all \
+    make \
+&& rm -rf /var/lib/apt/lists/*
+
+# ---
+# Install python
+RUN if [ $PYVERSION -eq 3 ] \
+    ; then \
+        apt update \
+        && apt install -y --no-install-recommends \
+            python3 \
+            python3-distutils \
+            python3-pip \
+            python3-venv \
+        && rm -rf /var/lib/apt/lists/* \
+        && ln -s /usr/bin/python3 /usr/bin/py \
+    ; else \
+        echo "Install from source" \
+        && apt update \
+        && apt install -y --no-install-recommends \
+            build-essential \
+            gdb \
+            lcov \
+            libbz2-dev \
+            libffi-dev \
+            libgdbm-dev \
+            libgdbm-compat-dev \
+            liblzma-dev \
+            libncurses5-dev \
+            libreadline6-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            lzma lzma-dev \
+            pkg-config \
+            tk-dev \
+            uuid-dev \
+            zlib1g-dev \
+        && rm -rf /var/lib/apt/lists/* \
+        && cd /opt \
+        && git clone --branch $PYVERSION --single-branch https://github.com/python/cpython \
+        && cd cpython \
+        && ./configure --prefix=/usr\
+        && make -j \
+        && make altinstall \
+        && ln -s /usr/bin/python$PYVERSION /usr/bin/py \
+    ; fi
+
+
+# ---
+# Install tools needed for building docs
+RUN apt update \
+&& apt install -y --no-install-recommends \
+    graphviz \
+    inkscape \
+    latexmk \
+    texlive-fonts-recommended \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    texlive-xetex \
+    xindy \
+&& rm -rf /var/lib/apt/lists/*
+
+USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,13 +4,13 @@ ARG PYVERSION=3
 
 # ---
 # Create the default user - vscode mounts workspace directory chowned to 1000:1000
-ARG USERNAME=vscode
+ARG USERNAME=gpiozero
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
 && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-&& apt-get update \
-&& apt-get install -y sudo \
+&& apt update \
+&& apt install -y sudo \
 && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
 && chmod 0440 /etc/sudoers.d/$USERNAME
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "name": "gpiozero",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            // PYVERSION 3 (default) will be obtained via apt
+            // Setting specific PYVERSION (not 3) will build from source
+            // "PYVERSION": "3.12",
+            "DEBIAN": "bookworm" // 3.11
+            // "DEBIAN": "bullseye" // 3.9
+            // "DEBIAN": "buster" // 3.7
+        }
+    },
+
+    "forwardPorts": [8000],
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": ".devcontainer/.venv/bin/python3",
+                "python.testing.pytestEnabled": true,
+                "terminal.integrated.defaultProfile.linux": "bash", 
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/usr/bin/bash"
+                    }
+                }
+            }
+        }
+    },
+
+    "postCreateCommand": ".devcontainer/postcreate.sh",
+    "postStartCommand": "nohup bash -c '. .devcontainer/.venv/bin/activate && make preview &'",
+    "postAttachCommand": ". .devcontainer/.venv/bin/activate"
+}

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,0 +1,11 @@
+echo "Removing old venv"
+rm -rf .devcontainer/.venv
+echo "Creating new venv"
+py -m venv .devcontainer/.venv
+. .devcontainer/.venv/bin/activate
+echo "Make gpiozero develop"
+make develop
+echo "Make docs clean"
+make -C docs clean
+echo "Make html docs"
+make -C docs html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
+            python: "3.7"
+            experimental: false
+          - os: ubuntu-20.04
+            python: "3.8"
+            experimental: false
+          - os: ubuntu-20.04
             python: "3.9"
             experimental: false
           - os: ubuntu-20.04
@@ -20,6 +26,10 @@ jobs:
           - os: ubuntu-22.04
             python: "3.11"
             experimental: false
+          - os: ubuntu-22.04
+            python: "3.12"
+            experimental: false
+
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
@@ -35,7 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        make develop
+        pip install -e .[test]
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -43,4 +39,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -k 'not test_real_pins.py'
+        pytest -v -k 'not test_real_pins.py' --cov
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim
 *.swp
+.vscode
+*.code-workspace
 tags
 
 # Packaging detritus
@@ -21,3 +24,6 @@ coverage
 .cache
 .pytest_cache
 .mypy_cache
+
+# Background docs preview
+nohup.out

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -11,6 +11,13 @@ Backwards Compatibility
 
 .. currentmodule:: gpiozero
 
+We aim to ensure that gpiozero will run on all versions of python included in releases
+of debian which are under full support from debian.org. At the moment this means python3.7
+(debian-buster), 3.9 (bullseye) & 3.11 (bookworm). While we will make a reasonable best
+effort not to break compatibility with older python 3.x versions and to provide support for
+higher versions not bundled in the latest stable debian release, python 3.7 is currently the
+lowest version supported.
+
 GPIO Zero 2.x is a new major version and thus backwards incompatible changes
 can be expected. We have attempted to keep these as minimal as reasonably
 possible while taking advantage of the opportunity to clean up things. This
@@ -139,12 +146,6 @@ By far the biggest and most important change is that the Python 2.x series is
 no longer supported (in practice, this means Python 2.7 is no longer
 supported). If your code is not compatible with Python 3, you should follow the
 `porting guide`_ in the `Python documentation`_.
-
-As of GPIO Zero 2.0, the lowest supported Python version will be 3.5. This base
-version may advance with minor releases, but we will make a reasonable best
-effort not to break compatibility with old Python 3.x versions, and to ensure
-that GPIO Zero can run on the version of Python in Debian oldstable at the
-time of its release.
 
 
 RPIO pin factory removed

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -93,6 +93,16 @@ To remove your installation, destroy the sandbox and the clone:
     $ rmvirtualenv gpiozero
     $ rm -rf ~/gpiozero
 
+If you prefer, there is also a devcontainer and associated Dockerfile which 
+will create a minimal debian installation with the required packages to code 
+and test gpiozero and to build and preview the docs. It is worth checking the 
+section on :ref:`mock-pins` in the :doc:`api_pins` chapter for guidance on 
+working without a Pi. The docs will be built and a previewer started on 
+localhost:8000 when you start the container.
+This environment is provided for those who are used to coding this way, to save 
+you the effort of setting it up yourself. It is not recommended as a starting 
+point.
+
 
 Building the docs
 =================

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -949,10 +949,20 @@ class LEDCharDisplay(LEDCollection):
 
         if font is None:
             if len(pins) == 7:
-                with resources.files('gpiozero.fonts').joinpath('7seg.txt').open() as f:
+                try:
+                    fontpath = resources.files('gpiozero.fonts').joinpath('7seg.txt')
+                except AttributeError:
+                    import importlib_resources # for python3.7 compatibility
+                    fontpath = importlib_resources.files('gpiozero.fonts').joinpath('7seg.txt')
+                with fontpath.open() as f:
                     font = load_font_7seg(f)
             elif len(pins) == 14:
-                with resources.files('gpiozero.fonts').joinpath('14seg.txt').open() as f:
+                try:
+                    fontpath = resources.files('gpiozero.fonts').joinpath('14seg.txt')
+                except AttributeError:
+                    import importlib_resources # for python3.7 compatibility
+                    fontpath = importlib_resources.files('gpiozero.fonts').joinpath('14seg.txt')
+                with fontpath.open() as f:
                     font = load_font_14seg(f)
             else:
                 # Construct a default dict containing a definition for " "

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -23,7 +23,7 @@ from itertools import repeat, cycle, chain, tee
 from threading import Lock
 from collections import OrderedDict, Counter, namedtuple
 from collections.abc import MutableMapping
-from importlib import resources
+from importlib import resources  
 from pprint import pformat
 
 from .exc import (
@@ -51,6 +51,12 @@ from .threads import GPIOThread
 from .devices import Device, CompositeDevice
 from .mixins import SharedMixin, SourceMixin, HoldMixin, event
 from .fonts import load_font_7seg, load_font_14seg
+
+try:  
+    fontslocation = resources.files('gpiozero.fonts')
+except AttributeError:
+    import importlib_resources
+    fontslocation = importlib_resources.files('gpiozero.fonts')
 
 
 def pairwise(it):
@@ -949,19 +955,11 @@ class LEDCharDisplay(LEDCollection):
 
         if font is None:
             if len(pins) == 7:
-                try:
-                    fontpath = resources.files('gpiozero.fonts').joinpath('7seg.txt')
-                except AttributeError:
-                    import importlib_resources # for python3.7 compatibility
-                    fontpath = importlib_resources.files('gpiozero.fonts').joinpath('7seg.txt')
+                fontpath = fontslocation.joinpath('7seg.txt')
                 with fontpath.open() as f:
                     font = load_font_7seg(f)
             elif len(pins) == 14:
-                try:
-                    fontpath = resources.files('gpiozero.fonts').joinpath('14seg.txt')
-                except AttributeError:
-                    import importlib_resources # for python3.7 compatibility
-                    fontpath = importlib_resources.files('gpiozero.fonts').joinpath('14seg.txt')
+                fontpath = fontslocation.joinpath('14seg.txt')
                 with fontpath.open() as f:
                     font = load_font_14seg(f)
             else:

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -16,7 +16,6 @@ import warnings
 from collections import namedtuple
 from itertools import chain
 from types import FunctionType
-from importlib.metadata import entry_points
 
 from .threads import _threads_shutdown
 from .mixins import (
@@ -34,6 +33,8 @@ from .exc import (
     NativePinFactoryFallback,
     PinFactoryFallback,
 )
+
+from .ep import PinFactory_entry_points
 
 from .compat import frozendict
 
@@ -300,15 +301,10 @@ class Device(ValuesMixin, GPIOBase):
             # entry-point. Try with name verbatim first. If that fails, attempt
             # with the lower-cased name (this ensures compatibility names work
             # but we're still case insensitive for all factories)
-            with warnings.catch_warnings():
-                # The dict interface of entry_points is deprecated ... already
-                # and this deprecation is for us to worry about, not our users
-                warnings.simplefilter('ignore', category=DeprecationWarning)
-                group = entry_points()['gpiozero_pin_factories']
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name:
                     return ep.load()()
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name.lower():
                     return ep.load()()
             raise BadPinFactory(f'Unable to find pin factory {name!r}')

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -1,0 +1,25 @@
+"""
+Provides access to the gpiozero entry points:
+
+.. code-block:: python
+    from gpiozero.ep import PinFactory_entry_points
+    
+    for ep in PinFactory_entry_points:
+        ...
+
+"""
+try:
+    from importlib.metadata import entry_points
+except ModuleNotFoundError:
+    from importlib_metadata import entry_points
+
+#prefix _ will stop this being imported via from ep import * if anyone tries
+def _get_entry_points(group): 
+    try: #dict interface deprecated in Python 3.12
+        _entry_points = entry_points(group=group)
+    except TypeError: #selectable entrypoints only available from Python 3.10
+        _entry_points = entry_points()[group]
+    return _entry_points    
+
+PinFactory_entry_points = _get_entry_points(group='gpiozero_pin_factories')
+MockPinClass_entry_points = _get_entry_points(group='gpiozero_mock_pin_classes')

--- a/gpiozerocli/__init__.py
+++ b/gpiozerocli/__init__.py
@@ -10,8 +10,10 @@ import os
 import sys
 import argparse
 
-from importlib.metadata import version
-
+try:
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    from importlib_metadata import version
 
 class CliTool:
     """

--- a/scripts/class_graph
+++ b/scripts/class_graph
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/scripts/previewer
+++ b/scripts/previewer
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,9 @@ gpiozero_mock_pin_classes =
     mocktriggerpin   = gpiozero.pins.mock:MockTriggerPin
 
 [tool:pytest]
-addopts = -rsx --cov --tb=short
+# addopts = -rsx --cov --tb=short
+# Uncomment the above line to provide basic coverage information in local runs
+# Comment out the above line to allow for debugging of tests (broken by --cov)
 testpaths = tests
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,10 @@ classifiers =
 
 [options]
 packages = find:
-python_requres = >=3.9
+python_requires = >=3.7
 install_requires =
     colorzero
+    importlib_resources;python_version<'3.9'
 
 [options.package_data]
 gpiozero =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ from gpiozero.pins.mock import MockFactory, MockPWMPin
 if sys.version_info[:2] < (3, 4):
     warnings.simplefilter('always')
 
+# To allow @pytest.mark.xfail(condition=python_version<3.10) or similar
+python_version = sys.version_info.major + (sys.version_info.minor/100)
+
 @pytest.fixture()
 def no_default_factory(request):
     save_pin_factory = Device.pin_factory

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1568,6 +1568,17 @@ def test_led_char_display_init(mock_factory):
     with LEDCharDisplay(*range(10, 17), initial_value=None) as char:
         assert char.value == '2'
 
+@pytest.mark.parametrize(
+        ('pins','defaultfont'),
+        [
+            pytest.param(range(4, 11), load_font_7seg('gpiozero/fonts/7seg.txt'), id='7-pin'),
+            pytest.param(range(4, 18), load_font_14seg('gpiozero/fonts/14seg.txt'), id='14-pin'),
+        ]
+)
+def test_led_char_display_default_font(mock_factory, pins, defaultfont):
+    with LEDCharDisplay(*pins) as char:
+        assert char.font == defaultfont
+
 def test_led_char_display_value(mock_factory):
     pins = [mock_factory.pin(i) for i in range(4, 11)]
     dp_pin = mock_factory.pin(11)

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -15,7 +15,6 @@ import pytest
 from gpiozero import *
 from gpiozero.pins.mock import *
 
-
 def test_mock_pin_init(mock_factory):
     with pytest.raises(ValueError):
         Device.pin_factory.pin(60)
@@ -236,3 +235,13 @@ def test_mock_charging_pin(mock_factory):
     pin.function = 'input'
     sleep(0.1)
     assert pin.state == 1
+
+def test_override_pin_class(no_default_factory):
+    factory = MockFactory(pin_class='mocktriggerpin')
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)
+
+def test_override_pin_class_capitalisation(no_default_factory):
+    factory = MockFactory(pin_class='MockTriggerPin')
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -90,7 +90,6 @@ def test_pi_revision():
             with pytest.raises(PinUnknownPi):
                 PiBoardInfo.from_revision(0xfff)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info():
     r = pi_info('900011')
     assert r.model == 'B'
@@ -119,7 +118,6 @@ def test_pi_info():
     assert repr(r).startswith('PiBoardInfo(revision=')
     assert 'headers=...' in repr(r)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info_other_types():
     assert pi_info(b'9000f1') == pi_info(0x9000f1)
 


### PR DESCRIPTION
- compatibility restored by using `importlib` backports as needed
- aim to ensure compatibility is maintained by running tests against 3.7 in pipeline
- documentation updated to reflect the policy of supporting oldoldstable

Note: supporting 3.6 would require additional backports to be used; supporting 3.5 is not feasible (pip doesn't support it anymore and f-strings would break)

I've moved the handling of  `entry_points` to a dedicated module as the specifics are different for each version. The approach implemented also provides forward compatibility with 3.12

Sphinx 4.0 is not available for python3.7 - so I had to change the pipeline to only install test dependencies, not `make develop` - this is also faster anyway

I put dev containers in place so I could code and verify specifically on buster, bullseye and bookworm. I've left them (with a note in the Developing chapter docs) as they could be useful to others and don't harm.

This closes #1113