### PR TITLE
Support venv and use of github actions for contributors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,8 @@ jobs:
     - name: Run tests
       run: |
         pytest -v -k 'not test_real_pins.py' --cov
+
+    # This only runs if you have a codecov.io account set up and linked,
+    # otherwise it will fail silently
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        make develop
+        pip install -e .[test]
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -k 'not test_real_pins.py'
+        pytest -v -k 'not test_real_pins.py' --cov

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.vim
 *.swp
 tags
+# If you wish to contribute and use a different editor, please don't 
+# extend this list, or it will quickly get very long.
+# Instead create a '.gitignore-global' file in your home directory and 
+# run 'git config --global core.excludesfile ~/.gitignore-global'
 
 # Packaging detritus
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@
 *.vim
 *.swp
 tags
-# If you wish to contribute and use a different editor, please don't 
-# extend this list, or it will quickly get very long.
-# Instead create a '.gitignore-global' file in your home directory and 
-# run 'git config --global core.excludesfile ~/.gitignore-global'
+# If you wish to contribute and use a different editor, feel free to 
+# extend this list.
+# Alternatively, you can create a '.gitignore-global' file in your home
+# directory and run 'git config --global core.excludesfile ~/.gitignore-global'
 
 # Packaging detritus
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim

--- a/scripts/class_graph
+++ b/scripts/class_graph
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/scripts/previewer
+++ b/scripts/previewer
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,9 @@ gpiozero_mock_pin_classes =
     mocktriggerpin   = gpiozero.pins.mock:MockTriggerPin
 
 [tool:pytest]
-addopts = -rsx --cov --tb=short
+# addopts = -rsx --cov --tb=short
+# Uncomment the above line to provide basic coverage information in local runs
+# Comment out the above line to allow for debugging of tests (broken by --cov)
 testpaths = tests
 
 [coverage:run]


### PR DESCRIPTION
Resolves #1109

The current .gitignore, setup.py and test.yml are focussed on a specific development set up.
These changes support a few additional development setup preferences without breaking anything. (Do no harm):
- Using pythons venv virtual environments,
- using editors other than vim
- debugging (via) tests,
- leveraging github actions for regression testing,
- visualising code coverage results on codecov.io

Each of these adjustments do no harm, and are individually committed to allow for cherry-picking if there is something you do not like.

If these changes are not integrated into the main codebase then any PRs raised by someone who has made a similar adjustment to support their environment will either silently include them or need rebasing before raising and then be prone to error due to a large number of changes suddenly being present in working tree, regression testing not executing etc. on the final code included in the PR.

A note on codecov.io - the action will do nothing if the repo is not previously linked, so there is no data uploaded etc. unless the repo owner has specifically set this up in advance. I.e. no harm in the action being present at the end of the pipeline.