### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/__init__.py
+++ b/gpiozero/__init__.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/compat.py
+++ b/gpiozero/compat.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/exc.py
+++ b/gpiozero/exc.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/fonts/__init__.py
+++ b/gpiozero/fonts/__init__.py
@@ -57,7 +57,7 @@ def load_segment_font(filename_or_obj, width, height, pins):
         filename_or_obj = filename_or_obj.decode('utf-8')
     opened = isinstance(filename_or_obj, (str, Path))
     if opened:
-        filename_or_obj = io.open(filename_or_obj, 'r')
+        filename_or_obj = open(filename_or_obj)
     try:
         lines = filename_or_obj.read()
         if isinstance(lines, bytes):

--- a/gpiozero/fonts/__init__.py
+++ b/gpiozero/fonts/__init__.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import io
 from collections import Counter
 from itertools import zip_longest
 from pathlib import Path

--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -173,7 +172,7 @@ class PingServer(PolledInternalDevice):
         # call gethostbyname in the constructor and ping that instead (good
         # for consistency, but what if the user *expects* the host to change
         # address?)
-        with io.open(os.devnull, 'wb') as devnull:
+        with open(os.devnull, 'wb') as devnull:
             try:
                 subprocess.check_call(
                     ['ping', '-c1', self.host],
@@ -293,7 +292,7 @@ class CPUTemperature(PolledInternalDevice):
         """
         Returns the current CPU temperature in degrees celsius.
         """
-        with io.open(self.sensor_file, 'r') as f:
+        with open(self.sensor_file) as f:
             return float(f.read().strip()) / 1000
 
     @property
@@ -431,7 +430,7 @@ class LoadAverage(PolledInternalDevice):
         """
         Returns the current load average.
         """
-        with io.open(self.load_average_file, 'r') as f:
+        with open(self.load_average_file) as f:
             file_columns = f.read().strip().split()
             return float(file_columns[self._load_average_file_column])
 

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import io
 import warnings
 import subprocess
 from datetime import datetime, time

--- a/gpiozero/mixins.py
+++ b/gpiozero/mixins.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/output_devices.py
+++ b/gpiozero/output_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/data.py
+++ b/gpiozero/pins/data.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -341,21 +341,21 @@ class LGPIOHardwareSPI(SPI):
         self._check_open()
         count, data = lgpio.spi_read(self._handle, n)
         if count < 0:
-            raise IOError(f'SPI transfer error {count}')
+            raise OSError(f'SPI transfer error {count}')
         return [int(b) for b in data]
 
     def write(self, data):
         self._check_open()
         count = lgpio.spi_write(self._handle, data)
         if count < 0:
-            raise IOError(f'SPI transfer error {count}')
+            raise OSError(f'SPI transfer error {count}')
         return len(data)
 
     def transfer(self, data):
         self._check_open()
         count, data = lgpio.spi_xfer(self._handle, data)
         if count < 0:
-            raise IOError(f'SPI transfer error {count}')
+            raise OSError(f'SPI transfer error {count}')
         return [int(b) for b in data]
 
 

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -32,12 +31,12 @@ from ..exc import DeviceClosed, PinUnknownPi, SPIInvalidClockMode
 def get_pi_revision():
     revision = None
     try:
-        with io.open('/proc/device-tree/system/linux,revision', 'rb') as f:
+        with open('/proc/device-tree/system/linux,revision', 'rb') as f:
             revision = hex(struct.unpack('>L', f.read(4))[0])[2:]
-    except IOError as e:
+    except OSError as e:
         if e.errno != errno.ENOENT:
             raise e
-        with io.open('/proc/cpuinfo', 'r') as f:
+        with open('/proc/cpuinfo') as f:
             for line in f:
                 if line.startswith('Revision'):
                     revision = line.split(':')[1].strip().lower()

--- a/gpiozero/pins/local.py
+++ b/gpiozero/pins/local.py
@@ -7,7 +7,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import io
 import errno
 import struct
 from collections import defaultdict

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/native.py
+++ b/gpiozero/pins/native.py
@@ -7,7 +7,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import io
 import os
 import sys
 import mmap

--- a/gpiozero/pins/pi.py
+++ b/gpiozero/pins/pi.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/pigpio.py
+++ b/gpiozero/pins/pigpio.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -90,7 +89,7 @@ class PiGPIOFactory(PiFactory):
         # Annoyingly, pigpio doesn't raise an exception when it fails to make a
         # connection; it returns a valid (but disconnected) pi object
         if self.connection is None:
-            raise IOError(f'failed to connect to {host}:{port}')
+            raise OSError(f'failed to connect to {host}:{port}')
         self._host = host
         self._port = port
         self._spis = []
@@ -444,7 +443,7 @@ class PiGPIOHardwareSPI(SPI):
         self._check_open()
         count, data = self.pin_factory.connection.spi_xfer(self._handle, data)
         if count < 0:
-            raise IOError(f'SPI transfer error {count}')
+            raise OSError(f'SPI transfer error {count}')
         # Convert returned bytearray to list of ints.
         # XXX Not sure how non-byte sized words (aux intf only) are returned
         # ... padded to 16/32-bits?
@@ -582,7 +581,7 @@ class PiGPIOSoftwareSPI(SPI):
         count, data = self.pin_factory.connection.bb_spi_xfer(
             self._select_pin, data)
         if count < 0:
-            raise IOError(f'SPI transfer error {count}')
+            raise OSError(f'SPI transfer error {count}')
         # Convert returned bytearray to list of ints. bb_spi only supports
         # byte-sized words so no issues here
         return [int(b) for b in data]

--- a/gpiozero/pins/rpigpio.py
+++ b/gpiozero/pins/rpigpio.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/spi.py
+++ b/gpiozero/pins/spi.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/pins/style.py
+++ b/gpiozero/pins/style.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -37,7 +36,7 @@ class Style:
     def _term_supports_color():
         try:
             stdout_fd = sys.stdout.fileno()
-        except IOError:
+        except OSError:
             return False
         else:
             is_a_tty = os.isatty(stdout_fd)

--- a/gpiozero/spi_devices.py
+++ b/gpiozero/spi_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/threads.py
+++ b/gpiozero/threads.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/tones.py
+++ b/gpiozero/tones.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozero/tools.py
+++ b/gpiozero/tools.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozerocli/__init__.py
+++ b/gpiozerocli/__init__.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/gpiozerocli/pinout.py
+++ b/gpiozerocli/pinout.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -61,7 +60,7 @@ class PinoutTool(CliTool):
                 except ImportError:
                     sys.stderr.write(self.get_gpiozero_help())
                     return 1
-                except IOError:
+                except OSError:
                     sys.stderr.write('Unrecognized board')
                     return 1
             else:

--- a/gpiozerocli/pintest.py
+++ b/gpiozerocli/pintest.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -55,7 +54,7 @@ class PintestTool(CliTool):
             except ImportError:
                 sys.stderr.write(self.get_gpiozero_help())
                 return 1
-            except IOError:
+            except OSError:
                 sys.stderr.write('Unrecognized board')
                 return 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -16,7 +16,7 @@ from gpiozero import *
 from gpiozero.pins.mock import MockFactory
 
 
-file_not_found = IOError(errno.ENOENT, 'File not found')
+file_not_found = OSError(errno.ENOENT, 'File not found')
 
 
 def test_default_pin_factory_order():

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -4,13 +4,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import (
-    unicode_literals,
-    absolute_import,
-    print_function,
-    division,
-)
-str = type('')
+str = str
 
 import io
 

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-str = str
-
 import io
 
 import pytest

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -20,7 +20,7 @@ import pytest
 from gpiozero import *
 from datetime import datetime, time
 
-file_not_found = IOError(errno.ENOENT, 'File not found')
+file_not_found = OSError(errno.ENOENT, 'File not found')
 bad_ping = CalledProcessError(1, 'returned non-zero exit status 1')
 
 
@@ -187,12 +187,12 @@ def test_pingserver_value(mock_factory):
             assert server.is_active
 
 def test_cputemperature_bad_init(mock_factory):
-    with mock.patch('io.open', mock.mock_open()) as m:
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open()) as m:
         m.side_effect = file_not_found
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             with CPUTemperature('') as temp:
                 temp.value
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             with CPUTemperature('badfile') as temp:
                 temp.value
         m.return_value.__enter__.return_value.readline.return_value = '37000'
@@ -204,7 +204,7 @@ def test_cputemperature_bad_init(mock_factory):
             CPUTemperature(min_temp=20, max_temp=10)
 
 def test_cputemperature(mock_factory):
-    with mock.patch('io.open', mock.mock_open(read_data='37000')) as m:
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open(read_data='37000')) as m:
         with CPUTemperature() as cpu:
             assert repr(cpu).startswith('<gpiozero.CPUTemperature object')
             assert cpu.temperature == 37.0
@@ -222,15 +222,15 @@ def test_cputemperature(mock_factory):
             assert cpu.is_active
 
 def test_loadaverage_bad_init(mock_factory):
-    with mock.patch('io.open', mock.mock_open()) as m:
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open()) as m:
         m.side_effect = file_not_found
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             with LoadAverage('') as load:
                 load.value
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             with LoadAverage('badfile') as load:
                 load.value
-    with mock.patch('io.open', mock.mock_open(read_data='0.09 0.10 0.09 1/292 20758')):
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open(read_data='0.09 0.10 0.09 1/292 20758')):
         with pytest.raises(ValueError):
             LoadAverage(min_load_average=1)
         with pytest.raises(ValueError):
@@ -243,7 +243,7 @@ def test_loadaverage_bad_init(mock_factory):
             LoadAverage(minutes=10)
 
 def test_loadaverage(mock_factory):
-    with mock.patch('io.open', mock.mock_open(read_data='0.09 0.10 0.09 1/292 20758')):
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open(read_data='0.09 0.10 0.09 1/292 20758')):
         with LoadAverage() as la:
             assert repr(la).startswith('<gpiozero.LoadAverage object')
             assert la.min_load_average == 0
@@ -253,7 +253,7 @@ def test_loadaverage(mock_factory):
             assert la.value == 0.1
             assert not la.is_active
         assert repr(la) == '<gpiozero.LoadAverage object closed>'
-    with mock.patch('io.open', mock.mock_open(read_data='1.72 1.40 1.31 3/457 23102')):
+    with mock.patch('gpiozero.internal_devices.open', mock.mock_open(read_data='1.72 1.40 1.31 3/457 23102')):
         with LoadAverage(min_load_average=0.5, max_load_average=2,
                          threshold=1, minutes=5) as la:
             assert la.min_load_average == 0.5

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -29,12 +29,12 @@ def test_pi_revision():
         # (MockPin simply parrots the 3B's data); LocalPiFactory is used as we
         # can definitely instantiate it (strictly speaking it's abstract but
         # we're only interested in the BoardInfo stuff)
-        with mock.patch('io.open') as m:
+        with mock.patch('gpiozero.pins.local.open') as m:
             m.return_value.__enter__.side_effect = [
                 # Pretend /proc/device-tree/system/linux,revision doesn't
                 # exist, and that /proc/cpuinfo contains the Revision: 0002
                 # after some filler
-                IOError(errno.ENOENT, 'File not found'),
+                OSError(errno.ENOENT, 'File not found'),
                 ['lots of irrelevant', 'lines', 'followed by', 'Revision: 0002', 'Serial:  xxxxxxxxxxx']
             ]
             assert Device.pin_factory.board_info.revision == '0002'
@@ -42,7 +42,7 @@ def test_pi_revision():
             # isn't going to change at runtime); we need to wipe it here though
             Device.pin_factory._info = None
             m.return_value.__enter__.side_effect = [
-                IOError(errno.ENOENT, 'File not found'),
+                OSError(errno.ENOENT, 'File not found'),
                 ['Revision: a21042']
             ]
             assert Device.pin_factory.board_info.revision == 'a21042'
@@ -50,13 +50,13 @@ def test_pi_revision():
             # or 8 character result; make sure both work)
             Device.pin_factory._info = None
             m.return_value.__enter__.side_effect = [
-                IOError(errno.ENOENT, 'File not found'),
+                OSError(errno.ENOENT, 'File not found'),
                 ['Revision: 1000003']
             ]
             assert Device.pin_factory.board_info.revision == '0003'
             Device.pin_factory._info = None
             m.return_value.__enter__.side_effect = [
-                IOError(errno.ENOENT, 'File not found'),
+                OSError(errno.ENOENT, 'File not found'),
                 ['Revision: 100003']
             ]
             assert Device.pin_factory.board_info.revision == '0003'
@@ -66,10 +66,10 @@ def test_pi_revision():
                 # Pretend /proc/device-tree/system/linux,revision doesn't
                 # exist, and that /proc/cpuinfo contains the Revision: 0002
                 # after some filler
-                IOError(errno.EACCES, 'Permission denied'),
+                OSError(errno.EACCES, 'Permission denied'),
                 ['Revision: 100003']
             ]
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 Device.pin_factory.board_info
             # Check that parsing /proc/device-tree/system/linux,revision also
             # works properly
@@ -82,7 +82,7 @@ def test_pi_revision():
                 Device.pin_factory._info = None
                 m.return_value.__enter__.return_value = None
                 m.return_value.__enter__.side_effect = [
-                    IOError(errno.ENOENT, 'File not found'),
+                    OSError(errno.ENOENT, 'File not found'),
                     ['nothing', 'relevant']
                 ]
                 Device.pin_factory.board_info
@@ -245,7 +245,7 @@ def test_pprint_style_detect():
     with mock.patch('sys.stdout') as stdout:
         stdout.output = []
         stdout.write = lambda buf: stdout.output.append(buf)
-        stdout.fileno.side_effect = IOError('not a real file')
+        stdout.fileno.side_effect = OSError('not a real file')
         board_info.pprint()
         s = ''.join(stdout.output)
         assert '\x1b[0m' not in s # default should output mono

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_spi_devices.py
+++ b/tests/test_spi_devices.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #

--- a/tests/test_tones.py
+++ b/tests/test_tones.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #
@@ -6,13 +5,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import (
-    unicode_literals,
-    absolute_import,
-    print_function,
-    division,
-)
-str = type('')
+str = str
 
 import warnings
 from fractions import Fraction

--- a/tests/test_tones.py
+++ b/tests/test_tones.py
@@ -5,8 +5,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-str = str
-
 import warnings
 from fractions import Fraction
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 #
 # GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
 #


### PR DESCRIPTION
Filter all code over `pyupgrade --py38-plus`.