### PR TITLE
Fix "blip" on setup of output with initial state (lgpio).

### DIFF
--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -150,6 +150,9 @@ class LGPIOPin(LocalPiPin):
             raise PinInvalidFunction(
                 f'invalid function "{value}" for pin {self!r}')
 
+    def output_with_state(self, state):
+        lgpio.gpio_claim_output(self.factory._handle, self._number, bool(state))
+
     def _get_state(self):
         if self._pwm:
             return self._pwm[1] / 100


### PR DESCRIPTION
When controling some relays, I noticed a "blip" (quick open/close) during setup. The culprit seems to be in the `output_with_state` function. I fixed it by overriding it in `LGPIOPin`, as described in the comment.