### PR TITLE
Add missing word to input_with_pin docstring

### DIFF
--- a/gpiozero/pins/__init__.py
+++ b/gpiozero/pins/__init__.py
@@ -272,7 +272,7 @@ class Pin:
             pin.function = 'input'
             pin.pull = pull
 
-        However, descendents may override this order to provide the smallest
+        However, descendents may override this in order to provide the smallest
         possible delay between configuring the pin for input and pulling the
         pin up/down (which can be important for avoiding "blips" in some
         configurations).


### PR DESCRIPTION
Compare to the docstring for `output_with_state` just a few lines earlier :wink: 