### PR TITLE
BUGFIX: Allow manual `chip` parameter in LGPIOFactory

### DIFF
--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -64,7 +64,7 @@ class LGPIOFactory(LocalPiFactory):
     def __init__(self, chip=None):
         super().__init__()
         if chip is None:
-            chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0
+            chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 and os.path.exists('/dev/gpiochip4') else 0
         self._handle = lgpio.gpiochip_open(chip)
         self._chip = chip
         self.pin_class = LGPIOPin

--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -63,7 +63,8 @@ class LGPIOFactory(LocalPiFactory):
     """
     def __init__(self, chip=None):
         super().__init__()
-        chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0
+        if chip is None:
+            chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0
         self._handle = lgpio.gpiochip_open(chip)
         self._chip = chip
         self.pin_class = LGPIOPin


### PR DESCRIPTION
This came up for me when using gpiozero on a new RaspberryPi 5, using the lgpio library I was able to access the gpio pins on chip 0, but when using gpiozero I was unable to access the pins. Looking further, I found that the LGPIO factory was always overwriting the `chip` variable. This is a simple fix for allowing the user to choose a gpiochip

Current Implementation: 

```python
    def __init__(self, chip=None):
        super().__init__()
        chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0
        self._handle = lgpio.gpiochip_open(chip)
        self._chip = chip
        self.pin_class = LGPIOPin
```

Proposed Implimentation:
```python
    def __init__(self, chip=None):
        super().__init__()
        if chip is None:
            chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0
        self._handle = lgpio.gpiochip_open(chip)
        self._chip = chip
        self.pin_class = LGPIOPin
```

in the current implimentation, the `chip` parameter will always be overwritten on line 66. I propose a simple fix by adding a `if not chip` check which will allow users to manually determine their chip. If chip is left blank, it will fall back to the default implimentation of `chip = 4 if (self._get_revision() & 0xff0) >> 4 == 0x17 else 0`

