### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python: "3.9"
             experimental: false
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python: "3.10"
             experimental: false
           - os: ubuntu-22.04
@@ -26,6 +26,9 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             python: "3.12"
+            experimental: false
+          - os: ubuntu-22.04
+            python: "3.13"
             experimental: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
* Bump all runners to Ubuntu 22.04 as Ubuntu 20.04 is no longer supported https://github.com/actions/runner-images/issues/11101
* Add Python 3.13 to the test-matrix