### PR TITLE
Update some URLs to their current location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ gpiozero
 A simple interface to GPIO devices with `Raspberry Pi`_, developed and
 maintained by `Ben Nuttall`_ and `Dave Jones`_.
 
-.. _Raspberry Pi: https://www.raspberrypi.org/
+.. _Raspberry Pi: https://www.raspberrypi.com/
 .. _Ben Nuttall: https://github.com/bennuttall
 .. _Dave Jones: https://github.com/waveform80
 
@@ -93,11 +93,11 @@ Installation
 ============
 
 GPIO Zero is installed by default in the Raspberry Pi OS desktop image,
-available from `raspberrypi.org`_. To install on Raspberry Pi OS Lite or other
+available from `raspberrypi.com`_. To install on Raspberry Pi OS Lite or other
 operating systems, including for PCs using remote GPIO, see the `Installing`_
 chapter.
 
-.. _raspberrypi.org: https://www.raspberrypi.org/software/
+.. _raspberrypi.com: https://www.raspberrypi.com/software/
 .. _Installing: https://gpiozero.readthedocs.io/en/stable/installing.html
 
 Documentation
@@ -121,7 +121,7 @@ Forums`_.
 .. _issue on GitHub: https://github.com/gpiozero/gpiozero/issues/new
 .. _GitHub discussion board: https://github.com/gpiozero/gpiozero/discussions
 .. _Raspberry Pi Stack Exchange: https://raspberrypi.stackexchange.com/
-.. _Raspberry Pi Forums: https://www.raspberrypi.org/forums/
+.. _Raspberry Pi Forums: https://forums.raspberrypi.com/
 
 Contributors
 ============

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -12,12 +12,12 @@ Installing GPIO Zero
 
 GPIO Zero is installed by default in the `Raspberry Pi OS`_ desktop image,  `Raspberry Pi OS`_ Lite image, and
 the `Raspberry Pi Desktop`_ image for PC/Mac, all available from
-`raspberrypi.org`_. Follow these guides to installing on other operating systems, including for PCs using the :doc:`remote GPIO
+`raspberrypi.com`_. Follow these guides to installing on other operating systems, including for PCs using the :doc:`remote GPIO
 <remote_gpio>` feature.
 
-.. _Raspberry Pi OS: https://www.raspberrypi.org/software/operating-systems/
-.. _Raspberry Pi Desktop: https://www.raspberrypi.org/software/raspberry-pi-desktop/
-.. _raspberrypi.org: https://www.raspberrypi.org/software/
+.. _Raspberry Pi OS: https://www.raspberrypi.com/software/operating-systems/
+.. _Raspberry Pi Desktop: https://www.raspberrypi.com/software/raspberry-pi-desktop/
+.. _raspberrypi.com: https://www.raspberrypi.com/software/
 
 Raspberry Pi
 ============
@@ -25,8 +25,8 @@ Raspberry Pi
 GPIO Zero is packaged in the apt repositories of Raspberry Pi OS, `Debian`_ and
 `Ubuntu`_. It is also available on `PyPI`_.
 
-.. _Debian: https://packages.debian.org/buster/python3-gpiozero
-.. _Ubuntu: https://packages.ubuntu.com/hirsute/python3-gpiozero
+.. _Debian: https://packages.debian.org/bookworm/python3-gpiozero
+.. _Ubuntu: https://packages.ubuntu.com/noble/python3-gpiozero
 .. _PyPI: https://pypi.org/project/gpiozero/
 
 apt

--- a/docs/pi_zero_otg.rst
+++ b/docs/pi_zero_otg.rst
@@ -31,7 +31,7 @@ Usage from Windows and Mac OS is not supported at present.
 Raspberry Pi Desktop x86 setup
 ------------------------------
 
-1. Download an ISO of the `Raspberry Pi Desktop OS`_ from raspberrypi.org
+1. Download an ISO of the `Raspberry Pi Desktop OS`_ from raspberrypi.com
 
 2. Write the image to a USB stick or burn to a DVD.
 
@@ -105,7 +105,7 @@ Zero:
 Alternatively, you can set the pin factory in-line, as explained in
 :doc:`remote_gpio`.
 
-Read more on the GPIO expander in blog posts on `raspberrypi.org`_ and
+Read more on the GPIO expander in blog posts on `raspberrypi.com`_ and
 `bennuttall.com`_.
 
 Legacy method - SD card required
@@ -144,10 +144,10 @@ IP address if you know it), for example:
     $ GPIOZERO_PIN_FACTORY=pigpio PIGPIO_ADDR=raspberrypi.local python3 led.py
 
 
-.. _Raspberry Pi Zero: https://www.raspberrypi.org/products/raspberry-pi-zero/
-.. _Pi Zero W: https://www.raspberrypi.org/products/raspberry-pi-zero-w/
-.. _Raspberry Pi Desktop OS: https://www.raspberrypi.org/downloads/raspberry-pi-desktop/
-.. _raspberrypi.org: https://www.raspberrypi.org/blog/gpio-expander/
+.. _Raspberry Pi Zero: https://www.raspberrypi.com/products/raspberry-pi-zero/
+.. _Pi Zero W: https://www.raspberrypi.com/products/raspberry-pi-zero-w/
+.. _Raspberry Pi Desktop OS: https://www.raspberrypi.com/software/raspberry-pi-desktop/
+.. _raspberrypi.com: https://www.raspberrypi.com/news/gpio-expander/
 .. _bennuttall.com: http://bennuttall.com/raspberry-pi-zero-gpio-expander/
 .. _blog.gbaman.info: http://blog.gbaman.info/?p=791
 .. _learn.adafruit.com: https://learn.adafruit.com/turning-your-raspberry-pi-zero-into-a-usb-gadget/ethernet-gadget

--- a/docs/recipes_remote_gpio.rst
+++ b/docs/recipes_remote_gpio.rst
@@ -82,4 +82,4 @@ Note that in this case, the Sense HAT code must be run locally, and the GPIO
 remotely.
 
 
-.. _Sense HAT: https://www.raspberrypi.org/products/sense-hat/
+.. _Sense HAT: https://www.raspberrypi.com/products/sense-hat/

--- a/docs/remote_gpio.rst
+++ b/docs/remote_gpio.rst
@@ -347,7 +347,7 @@ Continue to:
 .. _RPi.GPIO: https://pypi.python.org/pypi/RPi.GPIO
 .. _pigpio: http://abyz.me.uk/rpi/pigpio/python.html
 .. _abyz.me.uk: http://abyz.me.uk/rpi/pigpio/download.html
-.. _Raspberry Pi Desktop x86: https://www.raspberrypi.org/downloads/raspberry-pi-desktop/
+.. _Raspberry Pi Desktop x86: https://www.raspberrypi.com/software/raspberry-pi-desktop/
 .. _get-pip: https://pip.pypa.io/en/stable/installing/
 .. _follow this guide: https://projects.raspberrypi.org/en/projects/using-pip-on-windows
-.. _Sense HAT: https://www.raspberrypi.org/products/sense-hat/
+.. _Sense HAT: https://www.raspberrypi.com/products/sense-hat/

--- a/gpiozero/pins/data.py
+++ b/gpiozero/pins/data.py
@@ -681,7 +681,7 @@ CM4_J3 = (3, 1, {
 # http://elinux.org/RPi_HardwareHistory
 # http://elinux.org/RPi_Low-level_peripherals
 # https://git.drogon.net/?p=wiringPi;a=blob;f=wiringPi/wiringPi.c#l807
-# https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
+# https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-revision-codes
 
 PI_REVISIONS = {
     # rev     model    pcb_rev released soc        manufacturer ram   storage    usb eth wifi   bt     csi dsi headers                         board


### PR DESCRIPTION
A lot of the content that was originally at raspberrypi.org now lives at raspberrypi.com