### PR TITLE
add sequent support

### DIFF
--- a/gpiozero/input_devices.py
+++ b/gpiozero/input_devices.py
@@ -1368,3 +1368,15 @@ class RotaryEncoder(EventsMixin, CompositeDevice):
         beyond their limits.
         """
         return self._wrap
+
+class Potentiometer(SmoothedInputDevice):
+    """
+    Represents a potentiometer or analog input
+    Exposes voltage reading via read() method
+    """
+    def _state_to_value(self, state):
+        return float(state)
+
+    def read(self):
+        """Returns the current voltage in volts (0.0 - 10.0)"""
+        return self.value * 10.0

--- a/gpiozero/pins/sequent_microsystems.py
+++ b/gpiozero/pins/sequent_microsystems.py
@@ -1,0 +1,655 @@
+# vim: set fileencoding=utf-8:
+#
+# GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
+#
+# Copyright (c) 2016-2024 Dave Jones <dave@waveform.org.uk>
+# Copyright (c) 2020 Fangchen Li <fangchen.li@outlook.com>
+# Copyright (c) 2016 Andrew Scheller <github@loowis.durge.org>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import time
+from collections import namedtuple
+from time import monotonic
+from threading import Thread, Event
+from math import isclose
+
+from multiio import SMmultiio
+import megaind
+
+from ..exc import (
+    PinPWMUnsupported,
+    PinSetInput,
+    PinFixedPull,
+    PinInvalidPin,
+    PinInvalidFunction,
+    PinInvalidPull,
+    PinInvalidBounce,
+    )
+from .pi import PiPin, PiFactory
+
+PinState = namedtuple('PinState', ('timestamp', 'state'))
+
+
+class MultiIOAnalogPin(PiPin):
+    """
+    Input pin that reads a 0-10V analog input on the Multi-IO HAT via I2C.
+    """
+    def __init__(self, factory, info, stack=0, channel=1):
+        super().__init__(factory, info)
+        self._stack = stack
+        self._channel = channel
+        self._function = 'input'
+        self._pull = info.pull or 'floating'
+        self._state = 0.0
+        self._bounce = None
+        self._edges = 'both'
+        self._when_changed = None
+        self.card = SMmultiio(stack=stack)
+        self.clear_states()
+
+    def clear_states(self):
+        self._last_change = monotonic()
+        self.states = [PinState(0.0, self._state)]
+
+    def _get_function(self):
+        return self._function
+
+    def _set_function(self, value):
+        if value != 'input':
+            raise PinInvalidFunction('MultiIOAnalogPin is input-only')
+        self._function = value
+
+    def _get_state(self):
+        return self.card.get_u_in(self._channel) / 10.0
+
+    def _set_state(self, value):
+        raise PinSetInput(f'MultiIOAnalogPin is read-only: {self!r}')
+
+    def _get_frequency(self):
+        return None
+
+    def _set_frequency(self, value):
+        if value is not None:
+            raise PinPWMUnsupported()
+
+    def _get_pull(self):
+        return self._pull
+
+    def _set_pull(self, value):
+        if value not in ('floating', 'up', 'down'):
+            raise PinInvalidPull('pull must be floating, up, or down')
+        self._pull = value
+
+    def _get_bounce(self):
+        return self._bounce
+
+    def _set_bounce(self, value):
+        self._bounce = value
+
+    def _get_edges(self):
+        return self._edges
+
+    def _set_edges(self, value):
+        self._edges = value
+
+
+class MultiIOPin(PiPin):
+    """
+    Output pin that drives a relay channel on the Multi-IO HAT via I2C.
+    This class does *not* support PWM.
+    """
+    def __init__(self, factory, info, stack=0, channel=1):
+        super().__init__(factory, info)
+        self._function = 'input'
+        self._pull = info.pull or 'floating'
+        self._state = self._pull == 'up'
+        self._bounce = None
+        self._edges = 'both'
+        self._when_changed = None
+        self.clear_states()
+        self.card = SMmultiio(stack=stack)
+        self._channel = channel
+
+    def close(self):
+        self.when_changed = None
+        self.function = 'input'
+
+    def _get_function(self):
+        return self._function
+
+    def _set_function(self, value):
+        if value not in ('input', 'output'):
+            raise PinInvalidFunction('function must be input or output')
+        self._function = value
+        if value == 'input':
+            # Drive the input to the pull
+            self._set_pull(self._get_pull())
+
+    def _get_state(self):
+        return self._state
+
+    def _set_state(self, value):
+        if self._function == 'input':
+            raise PinSetInput(f'cannot set state of pin {self!r}')
+        assert self._function == 'output'
+        assert 0 <= value <= 1
+        self._change_state(bool(value))
+        self.card.set_relay(self._channel, 1 if value else 0)
+        time.sleep(0.05)  # let the I2C write settle on the card
+
+    def _change_state(self, value):
+        if self._state != value:
+            t = monotonic()
+            self._state = value
+            self.states.append(PinState(t - self._last_change, value))
+            self._last_change = t
+            return True
+        return False
+
+    def _get_frequency(self):
+        return None
+
+    def _set_frequency(self, value):
+        if value is not None:
+            raise PinPWMUnsupported()
+
+    def _get_pull(self):
+        return self._pull
+
+    def _set_pull(self, value):
+        if self.function != 'input':
+            raise PinFixedPull(f'cannot set pull on non-input pin {self!r}')
+        if self.info.pull and value != self.info.pull:
+            raise PinFixedPull(f'{self!r} has a fixed pull resistor')
+        if value not in ('floating', 'up', 'down'):
+            raise PinInvalidPull('pull must be floating, up, or down')
+        self._pull = value
+        if value == 'up':
+            self.drive_high()
+        elif value == 'down':
+            self.drive_low()
+
+    def _get_bounce(self):
+        return self._bounce
+
+    def _set_bounce(self, value):
+        # XXX Need to implement this
+        if value is not None:
+            try:
+                value = float(value)
+            except ValueError:
+                raise PinInvalidBounce('bounce must be None or a float')
+        self._bounce = value
+
+    def _get_edges(self):
+        return self._edges
+
+    def _set_edges(self, value):
+        assert value in ('none', 'falling', 'rising', 'both')
+        self._edges = value
+
+    def _disable_event_detect(self):
+        pass
+
+    def _enable_event_detect(self):
+        pass
+
+    def _call_when_changed(self):
+        super()._call_when_changed(self._last_change, self._state)
+
+    def drive_high(self):
+        assert self._function == 'input'
+        if self._change_state(True):
+            if self._edges in ('both', 'rising') and self._when_changed is not None:
+                self._call_when_changed()
+
+    def drive_low(self):
+        assert self._function == 'input'
+        if self._change_state(False):
+            if self._edges in ('both', 'falling') and self._when_changed is not None:
+                self._call_when_changed()
+
+    def clear_states(self):
+        self._last_change = monotonic()
+        self.states = [PinState(0.0, self._state)]
+
+    def assert_states(self, expected_states):
+        # Tests that the pin went through the expected states (a list of values)
+        for actual, expected in zip(self.states, expected_states):
+            assert actual.state == expected
+
+    def assert_states_and_times(self, expected_states):
+        # Tests that the pin went through the expected states at the expected
+        # times (times are compared with a tolerance of tens-of-milliseconds as
+        # that's about all we can reasonably expect in a non-realtime
+        # environment on a Pi 1)
+        for actual, expected in zip(self.states, expected_states):
+            assert isclose(actual.timestamp, expected[0], rel_tol=0.05, abs_tol=0.05)
+            assert isclose(actual.state, expected[1])
+
+
+class MegaindPin(PiPin):
+    """
+    Output pin that drives a digital output (OD) on the Megaind HAT via I2C.
+    """
+    def __init__(self, factory, info, stack=0, channel=1):
+        super().__init__(factory, info)
+        self._stack = stack
+        self._channel = channel
+        self._function = 'input'
+        self._pull = info.pull or 'floating'
+        self._state = False
+        self._frequency = None
+        self._bounce = None
+        self._edges = 'both'
+        self._when_changed = None
+        self.clear_states()
+
+    def close(self):
+        self.when_changed = None
+        self.function = 'input'
+
+    def clear_states(self):
+        self._last_change = monotonic()
+        self.states = [PinState(0.0, self._state)]
+
+    def _get_function(self):
+        return self._function
+
+    def _set_function(self, value):
+        if value not in ('input', 'output'):
+            raise PinInvalidFunction('function must be input or output')
+        self._function = value
+        if value == 'input':
+            # Drive the input to the pull
+            self._set_pull(self._get_pull())
+
+    def _get_state(self):
+        return self._state
+
+    def _set_state(self, value):
+        if self._function == 'input':
+            raise PinSetInput(f'cannot set state of pin {self!r}')
+        assert self._function == 'output'
+        assert 0 <= value <= 1
+        if self._frequency is None:
+            self._change_state(bool(value))
+            megaind.setOd(self._stack, self._channel, 1 if value else 0)
+        else:
+            self._change_state(float(value))
+            megaind.setOdPWM(self._stack, self._channel, float(value) * 100)
+        time.sleep(0.05)
+
+    def _change_state(self, value):
+        if self._state != value:
+            t = monotonic()
+            self._state = value
+            self.states.append(PinState(t - self._last_change, value))
+            self._last_change = t
+            return True
+        return False
+
+    def _get_frequency(self):
+        return self._frequency
+
+    def _set_frequency(self, value):
+        # The Megaind OD channels have a fixed-frequency hardware PWM
+        # generator; the requested Hz value can't be applied, it's only
+        # used here as an on/off switch between digital and PWM output.
+        self._frequency = value
+        if value is None:
+            self._change_state(False)
+            megaind.setOd(self._stack, self._channel, 0)
+
+    def _get_pull(self):
+        return self._pull
+
+    def _set_pull(self, value):
+        if self.function != 'input':
+            raise PinFixedPull(f'cannot set pull on non-input pin {self!r}')
+        if value not in ('floating', 'up', 'down'):
+            raise PinInvalidPull('pull must be floating, up, or down')
+        self._pull = value
+
+    def _get_bounce(self):
+        return self._bounce
+
+    def _set_bounce(self, value):
+        if value is not None:
+            try:
+                value = float(value)
+            except ValueError:
+                raise PinInvalidBounce('bounce must be None or a float')
+        self._bounce = value
+
+    def _get_edges(self):
+        return self._edges
+
+    def _set_edges(self, value):
+        assert value in ('none', 'falling', 'rising', 'both')
+        self._edges = value
+
+    def _disable_event_detect(self):
+        pass
+
+    def _enable_event_detect(self):
+        pass
+
+    def _call_when_changed(self):
+        super()._call_when_changed(self._last_change, self._state)
+
+
+class MegaindOptoPin(PiPin):
+    """
+    Input pin that reads an optocoupled input on the Megaind HAT via I2C.
+
+    I2C reads are not interrupt-driven, so change detection (used by
+    :attr:`when_changed`, e.g. :class:`~gpiozero.Button`) is implemented with
+    a background poll thread that is only running while a callback is
+    actually attached.
+    """
+    POLL_INTERVAL = 0.02
+
+    def __init__(self, factory, info, stack=0, channel=1):
+        super().__init__(factory, info)
+        self._stack = stack
+        self._channel = channel
+        self._function = 'input'
+        self._pull = info.pull or 'floating'
+        self._state = self._read_hw_state()
+        self._bounce = None
+        self._edges = 'both'
+        self._when_changed = None
+        self._poll_thread = None
+        self._poll_stop = Event()
+        self.clear_states()
+
+    def close(self):
+        self.when_changed = None
+
+    def clear_states(self):
+        self._last_change = monotonic()
+        self.states = [PinState(0.0, self._state)]
+
+    def _get_function(self):
+        return self._function
+
+    def _set_function(self, value):
+        if value != 'input':
+            raise PinInvalidFunction('MegaindOptoPin is input-only')
+        self._function = value
+
+    def _read_hw_state(self):
+        val = megaind.getOpto(self._stack)
+        return (val >> (self._channel - 1)) & 1
+
+    def _get_state(self):
+        self._change_state(self._read_hw_state())
+        return self._state
+
+    def _set_state(self, value):
+        raise PinSetInput(f'MegaindOptoPin is read-only: {self!r}')
+
+    def _change_state(self, value):
+        value = bool(value)
+        if self._state != value:
+            t = monotonic()
+            self._state = value
+            self.states.append(PinState(t - self._last_change, value))
+            self._last_change = t
+            return True
+        return False
+
+    def _get_frequency(self):
+        return None
+
+    def _set_frequency(self, value):
+        if value is not None:
+            raise PinPWMUnsupported()
+
+    def _get_pull(self):
+        return self._pull
+
+    def _set_pull(self, value):
+        if value not in ('floating', 'up', 'down'):
+            raise PinInvalidPull('pull must be floating, up, or down')
+        self._pull = value
+
+    def _get_bounce(self):
+        return self._bounce
+
+    def _set_bounce(self, value):
+        self._bounce = value
+
+    def _get_edges(self):
+        return self._edges
+
+    def _set_edges(self, value):
+        self._edges = value
+
+    def _call_when_changed(self):
+        super()._call_when_changed(self._last_change, self._state)
+
+    def _enable_event_detect(self):
+        if self._poll_thread is None:
+            self._poll_stop.clear()
+            self._poll_thread = Thread(target=self._poll_loop, daemon=True)
+            self._poll_thread.start()
+
+    def _disable_event_detect(self):
+        if self._poll_thread is not None:
+            self._poll_stop.set()
+            self._poll_thread.join()
+            self._poll_thread = None
+
+    def _poll_loop(self):
+        while not self._poll_stop.wait(self.POLL_INTERVAL):
+            value = bool(self._read_hw_state())
+            if self._change_state(value):
+                if self._edges in ('both', 'rising' if value else 'falling'):
+                    self._call_when_changed()
+
+
+class MultiIOFactory(PiFactory):
+    """
+    Factory for generating pins connected to a Sequent Microsystems Multi-IO
+    HAT over I2C.
+
+    The *stack* parameter identifies which physical board to talk to (the
+    hardware address set via the board's jumpers, 0-7). The *pin_type*
+    parameter selects which channel family the factory produces by default:
+    ``'relay'`` for :class:`MultiIOPin` or ``'analog_in'`` for
+    :class:`MultiIOAnalogPin`. This can be overridden per-call via the
+    *pin_class* argument to :meth:`pin`.
+
+    .. attribute:: pin_class
+
+        This attribute stores the pin class that will be used when
+        constructing pins with the :meth:`pin` method (if no *pin_class*
+        parameter is used to override it). It defaults on construction to
+        ``PIN_TYPES[pin_type]``.
+    """
+
+    PIN_TYPES = {
+        'relay':     MultiIOPin,
+        'analog_in': MultiIOAnalogPin,
+    }
+
+    def __init__(self, revision=None, stack=0, pin_type='relay'):
+        super().__init__()
+        if revision is None:
+            revision = os.environ.get('GPIOZERO_MOCK_REVISION', 'a02082')
+        self._revision = int(revision, base=16)
+        self.stack = stack
+        if pin_type not in self.PIN_TYPES:
+            raise ValueError(f'pin_type inconnu: {pin_type}')
+        self.pin_class = self.PIN_TYPES[pin_type]
+
+    def _get_revision(self):
+        return self._revision
+
+    def reset(self):
+        """
+        Clears the pins and reservations sets. This is primarily useful in
+        test suites to ensure the pin factory is back in a "clean" state before
+        the next set of tests are run.
+        """
+        self.pins.clear()
+        self._reservations.clear()
+
+    def pin(self, name, pin_class=None, **kwargs):
+        """
+        The pin method for :class:`MultiIOFactory` additionally takes a
+        *pin_class* attribute which can be used to override the class'
+        :attr:`pin_class` attribute. Any additional keyword arguments will be
+        passed along to the pin constructor.
+        """
+        if pin_class is None:
+            pin_class = self.pin_class
+        for header, info in self.board_info.find_pin(name):
+            try:
+                pin = self.pins[info]
+            except KeyError:
+                pin = pin_class(self, info, stack=self.stack, channel=name, **kwargs)
+                self.pins[info] = pin
+            else:
+                # Ensure the cached pin is compatible with what was requested
+                if not isinstance(pin, pin_class):
+                    raise ValueError(
+                        f'pin {info.name} is already in use as a '
+                        f'{pin.__class__.__name__}')
+            return pin
+        raise PinInvalidPin(f'{name} is not a valid pin name')
+
+    def relay(self, channel=1):
+        """
+        Return a :class:`MultiIORelay` wrapper for the given relay channel,
+        bypassing the :class:`~gpiozero.Pin`/:class:`LED` machinery.
+        """
+        return MultiIORelay(stack=self.stack, channel=channel)
+
+    def analog_in(self, channel=1):
+        """
+        Return a :class:`MultiIOAnalogInput` wrapper for the given analog
+        input channel, bypassing the :class:`~gpiozero.Pin`/
+        :class:`~gpiozero.Potentiometer` machinery.
+        """
+        return MultiIOAnalogInput(stack=self.stack, channel=channel)
+
+    @staticmethod
+    def ticks():
+        return monotonic()
+
+    @staticmethod
+    def ticks_diff(later, earlier):
+        return later - earlier
+
+
+class MegaindFactory(PiFactory):
+    """
+    Factory for generating pins connected to a Sequent Microsystems Megaind
+    HAT over I2C. Structurally identical to :class:`MultiIOFactory`, but
+    targets the Megaind board/library instead.
+
+    The *stack* parameter identifies which physical board to talk to (the
+    hardware address set via the board's jumpers, 0-7). The *pin_type*
+    parameter selects which channel family the factory produces by default:
+    ``'od'`` for :class:`MegaindPin` or ``'opto'`` for
+    :class:`MegaindOptoPin`.
+    """
+    PIN_TYPES = {
+        'od':   MegaindPin,
+        'opto': MegaindOptoPin,
+    }
+
+    def __init__(self, revision=None, stack=0, pin_type='od'):
+        super().__init__()
+        if revision is None:
+            revision = os.environ.get('GPIOZERO_MOCK_REVISION', 'a02082')
+        self._revision = int(revision, base=16)
+        self.stack = stack
+        if pin_type not in self.PIN_TYPES:
+            raise ValueError(f'pin_type inconnu: {pin_type}')
+        self.pin_class = self.PIN_TYPES[pin_type]
+
+    def _get_revision(self):
+        return self._revision
+
+    def reset(self):
+        """
+        Clears the pins and reservations sets. This is primarily useful in
+        test suites to ensure the pin factory is back in a "clean" state before
+        the next set of tests are run.
+        """
+        self.pins.clear()
+        self._reservations.clear()
+
+    def pin(self, name, pin_class=None, **kwargs):
+        """
+        The pin method for :class:`MegaindFactory` additionally takes a
+        *pin_class* attribute which can be used to override the class'
+        :attr:`pin_class` attribute. Any additional keyword arguments will be
+        passed along to the pin constructor.
+        """
+        if pin_class is None:
+            pin_class = self.pin_class
+        for header, info in self.board_info.find_pin(name):
+            try:
+                pin = self.pins[info]
+            except KeyError:
+                pin = pin_class(self, info, stack=self.stack, channel=name, **kwargs)
+                self.pins[info] = pin
+            else:
+                # Ensure the cached pin is compatible with what was requested
+                if not isinstance(pin, pin_class):
+                    raise ValueError(
+                        f'pin {info.name} is already in use as a '
+                        f'{pin.__class__.__name__}')
+            return pin
+        raise PinInvalidPin(f'{name} is not a valid pin name')
+
+    @staticmethod
+    def ticks():
+        return monotonic()
+
+    @staticmethod
+    def ticks_diff(later, earlier):
+        return later - earlier
+
+
+class MultiIOAnalogInput:
+    """
+    Reads a 0-10V analog input from a Sequent Multi-IO HAT
+    """
+    def __init__(self, stack=0, channel=1):
+        self._card = SMmultiio(stack=stack)
+        self._channel = channel
+
+    @property
+    def value(self):
+        """The reading normalized to 0.0-1.0 (0-10V)."""
+        return self._card.get_u_in(self._channel) / 10.0
+
+    @property
+    def volts(self):
+        """The raw reading in volts (0-10V)."""
+        return self._card.get_u_in(self._channel)
+
+
+class MultiIORelay:
+    """
+    Controls a relay output on a Sequent Multi-IO HAT
+    """
+    def __init__(self, stack=0, channel=1):
+        self._card = SMmultiio(stack=stack)
+        self._channel = channel
+
+    def on(self):
+        """Closes the relay."""
+        self._card.set_relay(self._channel, 1)
+
+    def off(self):
+        """Opens the relay."""
+        self._card.set_relay(self._channel, 0)

--- a/tests/test_real_pins.py
+++ b/tests/test_real_pins.py
@@ -27,13 +27,13 @@ from gpiozero.pins.mock import MockConnectedPin, MockFactory
 from gpiozero.pins.native import NativeFactory
 from gpiozero.pins.local import LocalPiFactory, LocalPiHardwareSPI
 
-
 # This module assumes you've wired the following GPIO pins together. The pins
 # can be re-configured via the listed environment variables (useful for when
 # your testing rig requires different pins because the defaults interfere with
 # attached hardware). Please note that the name specified *must* be the primary
 # name of the pin, e.g. GPIO22 rather than an alias like BCM22 or 22 (several
 # tests rely upon this).
+
 TEST_PIN = os.environ.get('GPIOZERO_TEST_PIN', 'GPIO22')
 INPUT_PIN = os.environ.get('GPIOZERO_TEST_INPUT_PIN', 'GPIO27')
 

--- a/tests/test_real_sequent_pins.py
+++ b/tests/test_real_sequent_pins.py
@@ -1,0 +1,89 @@
+# vim: set fileencoding=utf-8:
+#
+# GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
+#
+# Copyright (c) 2026 Marie Sauzay <marie.c.sauzay@gmail.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+from time import sleep
+
+import megaind
+import pytest
+from multiio import SMmultiio
+
+from gpiozero.pins.sequent_microsystems import MegaindFactory, MultiIOFactory
+
+
+# This module assumes a real Sequent Microsystems Megaind HAT and Multi-IO
+# HAT are attached to the I2C bus, both at the stack address below (their
+# address jumpers/switches set to 0, the factory default). Unlike
+# test_real_pins.py this isn't a loopback between two pins: each test writes
+# a real output channel and reads the same channel back through the vendor
+# library directly, independently of gpiozero's own cached pin state.
+STACK = int(os.environ.get('GPIOZERO_SEQUENT_STACK', '0'))
+OD_CHANNEL = int(os.environ.get('GPIOZERO_SEQUENT_OD_CHANNEL', '1'))
+RELAY_CHANNEL = int(os.environ.get('GPIOZERO_SEQUENT_RELAY_CHANNEL', '1'))
+
+# Prevents two real-hardware runs from fighting over the same I2C bus, same
+# idea as TEST_LOCK in test_real_pins.py
+TEST_LOCK = os.environ.get('GPIOZERO_SEQUENT_TEST_LOCK', '/tmp/real_sequent_pins_lock')
+
+
+def setup_module(module):
+    from time import time
+    start = time()
+    while True:
+        if time() - start > 60:
+            raise RuntimeError('timed out waiting for real sequent pins lock')
+        try:
+            with open(TEST_LOCK, 'x') as f:
+                f.write('Lock file for gpiozero real Sequent hardware tests; '
+                        'delete this if the test suite is not currently running\n')
+        except FileExistsError:
+            print('Waiting for lock before testing real Sequent hardware')
+            sleep(1)
+        else:
+            break
+
+
+def teardown_module(module):
+    os.unlink(TEST_LOCK)
+
+
+def test_megaind_pin_od_matches_hardware_readback():
+    factory = MegaindFactory(stack=STACK, pin_type='od')
+    try:
+        pin = factory.pin(OD_CHANNEL)
+        pin.function = 'output'
+        try:
+            pin.state = 1
+            sleep(0.1)
+            assert megaind.getOd(STACK, OD_CHANNEL) == 1
+            pin.state = 0
+            sleep(0.1)
+            assert megaind.getOd(STACK, OD_CHANNEL) == 0
+        finally:
+            pin.state = 0
+    finally:
+        factory.close()
+
+
+def test_multiio_pin_relay_matches_hardware_readback():
+    factory = MultiIOFactory(stack=STACK, pin_type='relay')
+    card = SMmultiio(stack=STACK)
+    try:
+        pin = factory.pin(RELAY_CHANNEL)
+        pin.function = 'output'
+        try:
+            pin.state = 1
+            sleep(0.1)
+            assert card.get_relay(RELAY_CHANNEL) == 1
+            pin.state = 0
+            sleep(0.1)
+            assert card.get_relay(RELAY_CHANNEL) == 0
+        finally:
+            pin.state = 0
+    finally:
+        factory.close()

--- a/tests/test_sequent_microsystems.py
+++ b/tests/test_sequent_microsystems.py
@@ -1,0 +1,594 @@
+# vim: set fileencoding=utf-8:
+#
+# GPIO Zero: a library for controlling the Raspberry Pi's GPIO pins
+#
+# Copyright (c) 2016-2024 Dave Jones <dave@waveform.org.uk>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from time import sleep
+from unittest import mock
+
+import pytest
+
+from gpiozero.exc import (
+    PinFixedPull,
+    PinInvalidBounce,
+    PinInvalidFunction,
+    PinInvalidPin,
+    PinInvalidPull,
+    PinPWMUnsupported,
+    PinSetInput,
+)
+from gpiozero.pins.sequent_microsystems import (
+    MegaindFactory,
+    MegaindOptoPin,
+    MegaindPin,
+    MultiIOAnalogInput,
+    MultiIOAnalogPin,
+    MultiIOFactory,
+    MultiIOPin,
+    MultiIORelay,
+)
+
+# test can be exercised without an actual I2C bus or board attached
+
+@pytest.fixture()
+def megaind_mod():
+    with mock.patch('gpiozero.pins.sequent_microsystems.megaind') as m:
+        m.getOpto.return_value = 0
+        yield m
+
+@pytest.fixture()
+def multiio_mod():
+    with mock.patch('gpiozero.pins.sequent_microsystems.SMmultiio') as cls:
+        yield cls.return_value
+
+@pytest.fixture()
+def megaind_od(megaind_mod):
+    factory = MegaindFactory(stack=0, pin_type='od')
+    yield factory
+    factory.close()
+
+@pytest.fixture()
+def megaind_opto(megaind_mod):
+    factory = MegaindFactory(stack=0, pin_type='opto')
+    yield factory
+    factory.close()
+
+@pytest.fixture()
+def multiio_relay(multiio_mod):
+    factory = MultiIOFactory(stack=0, pin_type='relay')
+    yield factory
+    factory.close()
+
+@pytest.fixture()
+def multiio_analog(multiio_mod):
+    factory = MultiIOFactory(stack=0, pin_type='analog_in')
+    yield factory
+    factory.close()
+
+# MegaindPin 
+
+def test_megaind_pin_defaults(megaind_od):
+    pin = megaind_od.pin(1)
+    assert isinstance(pin, MegaindPin)
+    assert pin.function == 'input'
+    assert pin.frequency is None
+    assert pin.state is False
+
+def test_megaind_pin_digital_on_calls_setOd(megaind_od, megaind_mod):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    pin.state = 1
+    megaind_mod.setOd.assert_called_with(0, 1, 1)
+    pin.state = 0
+    megaind_mod.setOd.assert_called_with(0, 1, 0)
+
+def test_megaind_pin_input_raises_on_set_state(megaind_od):
+    pin = megaind_od.pin(1)
+    with pytest.raises(PinSetInput):
+        pin.state = 1
+
+def test_megaind_pin_pwm_calls_setOdPWM(megaind_od, megaind_mod):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    pin.frequency = 100
+    pin.state = 0.5
+    megaind_mod.setOdPWM.assert_called_with(0, 1, 50.0)
+
+
+def test_megaind_pin_clearing_frequency_returns_to_digital(megaind_od, megaind_mod):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    pin.frequency = 100
+    pin.state = 0.5
+    pin.frequency = None
+    megaind_mod.setOd.assert_called_with(0, 1, 0)
+    assert pin.state is False
+
+
+def test_megaind_pin_invalid_function(megaind_od):
+    pin = megaind_od.pin(1)
+    with pytest.raises(PinInvalidFunction):
+        pin.function = 'bogus'
+
+
+# MegaindOptoPin
+
+def test_megaind_opto_pin_is_input_only(megaind_opto):
+    pin = megaind_opto.pin(1)
+    assert isinstance(pin, MegaindOptoPin)
+    assert pin.function == 'input'
+    with pytest.raises(PinInvalidFunction):
+        pin.function = 'output'
+
+
+def test_megaind_opto_pin_read_only(megaind_opto):
+    pin = megaind_opto.pin(1)
+    with pytest.raises(PinSetInput):
+        pin.state = 1
+
+
+def test_megaind_opto_pin_reads_bit_for_channel(megaind_opto, megaind_mod):
+    megaind_mod.getOpto.return_value = 0b0101
+    pin1 = megaind_opto.pin(1)
+    pin2 = megaind_opto.pin(2)
+    pin3 = megaind_opto.pin(3)
+    assert pin1.state == 1
+    assert pin2.state == 0
+    assert pin3.state == 1
+
+
+def test_megaind_opto_pin_fires_when_changed(megaind_opto, megaind_mod):
+    pin = megaind_opto.pin(1)
+    seen = []
+
+    # when_changed is stored as a weak reference (see PiPin._set_when_changed)
+    # so the callback must be kept alive by a local variable here, exactly as
+    # gpiozero's own tests do (see test_mock_pin.py's "changed" function) --
+    # an inline lambda would be garbage collected before the poll thread
+    # ever gets to call it.
+    def changed(ticks, state):
+        seen.append(state)
+
+    pin.when_changed = changed
+    megaind_mod.getOpto.return_value = 1
+    # The poll thread checks every POLL_INTERVAL (20ms); give it a few
+    # cycles to notice the change and fire the callback.
+    for _ in range(20):
+        if seen:
+            break
+        sleep(0.02)
+    assert seen == [True]
+    pin.close()
+
+# MultiIOPin
+
+def test_multiio_pin_defaults(multiio_relay):
+    pin = multiio_relay.pin(1)
+    assert isinstance(pin, MultiIOPin)
+    assert pin.function == 'input'
+    assert pin.frequency is None
+
+def test_multiio_pin_output_calls_set_relay(multiio_relay, multiio_mod):
+    pin = multiio_relay.pin(1)
+    pin.function = 'output'
+    pin.state = 1
+    multiio_mod.set_relay.assert_called_with(1, 1)
+    pin.state = 0
+    multiio_mod.set_relay.assert_called_with(1, 0)
+
+def test_multiio_pin_input_raises_on_set_state(multiio_relay):
+    pin = multiio_relay.pin(1)
+    with pytest.raises(PinSetInput):
+        pin.state = 1
+
+def test_multiio_pin_no_pwm(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'output'
+    with pytest.raises(PinPWMUnsupported):
+        pin.frequency = 100
+
+# MultiIOAnalogPin
+
+def test_multiio_analog_pin_is_input_only(multiio_analog):
+    pin = multiio_analog.pin(1)
+    assert isinstance(pin, MultiIOAnalogPin)
+    assert pin.function == 'input'
+    with pytest.raises(PinInvalidFunction):
+        pin.function = 'output'
+
+def test_multiio_analog_pin_reads_normalized_voltage(multiio_analog, multiio_mod):
+    multiio_mod.get_u_in.return_value = 5.0
+    pin = multiio_analog.pin(1)
+    assert pin.state == 0.5
+
+def test_multiio_analog_pin_read_only(multiio_analog):
+    pin = multiio_analog.pin(1)
+    with pytest.raises(PinSetInput):
+        pin.state = 0.5
+
+# Factories
+
+def test_factory_invalid_pin_type(megaind_mod, multiio_mod):
+    with pytest.raises(ValueError):
+        MegaindFactory(stack=0, pin_type='bogus')
+    with pytest.raises(ValueError):
+        MultiIOFactory(stack=0, pin_type='bogus')
+
+
+def test_factory_pin_is_cached(megaind_od):
+    pin1 = megaind_od.pin(1)
+    pin2 = megaind_od.pin(1)
+    assert pin1 is pin2
+
+
+def test_factory_pin_class_mismatch_raises(megaind_od):
+    megaind_od.pin(1)
+    with pytest.raises(ValueError):
+        megaind_od.pin(1, pin_class=MegaindOptoPin)
+
+
+def test_factory_default_pin_types(megaind_mod, multiio_mod):
+    assert MegaindFactory(stack=0).pin_class is MegaindPin
+    assert MegaindFactory(stack=0, pin_type='opto').pin_class is MegaindOptoPin
+    assert MultiIOFactory(stack=0).pin_class is MultiIOPin
+    assert MultiIOFactory(stack=0, pin_type='analog_in').pin_class is MultiIOAnalogPin
+
+
+# MultiIOAnalogPin
+
+def test_multiio_analog_pin_function_input_ok(multiio_analog):
+    pin = multiio_analog.pin(1)
+    pin.function = 'input'
+    assert pin.function == 'input'
+
+
+def test_multiio_analog_pin_no_pwm(multiio_analog):
+    pin = multiio_analog.pin(1)
+    assert pin.frequency is None
+    with pytest.raises(PinPWMUnsupported):
+        pin.frequency = 100
+
+
+def test_multiio_analog_pin_pull(multiio_analog):
+    pin = multiio_analog.pin(1)
+    assert pin.pull == 'floating'
+    pin.pull = 'up'
+    assert pin.pull == 'up'
+    with pytest.raises(PinInvalidPull):
+        pin.pull = 'bogus'
+
+
+def test_multiio_analog_pin_bounce_and_edges(multiio_analog):
+    pin = multiio_analog.pin(1)
+    assert pin.bounce is None
+    pin.bounce = 0.1
+    assert pin.bounce == 0.1
+    assert pin.edges == 'both'
+    pin.edges = 'rising'
+    assert pin.edges == 'rising'
+
+
+# MultiIOPin
+
+def test_multiio_pin_function_roundtrip(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'output'
+    assert pin.function == 'output'
+    pin.function = 'input'
+    assert pin.function == 'input'
+
+
+def test_multiio_pin_state_getter(multiio_relay):
+    pin = multiio_relay.pin(1)
+    assert pin.state in (0, False)
+
+
+def test_multiio_pin_no_pwm(multiio_relay):
+    pin = multiio_relay.pin(1)
+    with pytest.raises(PinPWMUnsupported):
+        pin.frequency = 100
+
+
+def test_multiio_pin_pull_requires_input_function(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'output'
+    with pytest.raises(PinFixedPull):
+        pin.pull = 'up'
+
+
+def test_multiio_pin_pull_invalid(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'input'
+    with pytest.raises(PinInvalidPull):
+        pin.pull = 'bogus'
+
+
+def test_multiio_pin_pull_up_down_drives_state(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'input'
+    pin.pull = 'up'
+    assert pin.state is True
+    pin.pull = 'down'
+    assert pin.state is False
+
+
+def test_multiio_pin_fixed_pull_resistor(multiio_relay):
+    pin = multiio_relay.pin(2)
+    pin.function = 'input'
+    with pytest.raises(PinFixedPull):
+        pin.pull = 'down'
+
+
+def test_multiio_pin_bounce(multiio_relay):
+    pin = multiio_relay.pin(1)
+    assert pin.bounce is None
+    pin.bounce = 0.1
+    assert pin.bounce == 0.1
+    with pytest.raises(PinInvalidBounce):
+        pin.bounce = 'not-a-number'
+
+
+def test_multiio_pin_edges(multiio_relay):
+    pin = multiio_relay.pin(1)
+    assert pin.edges == 'both'
+    pin.edges = 'falling'
+    assert pin.edges == 'falling'
+
+
+def test_multiio_pin_drive_high_low_fire_when_changed(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'input'
+    seen = []
+
+    def changed(ticks, state):
+        seen.append(state)
+
+    pin.when_changed = changed
+    pin.drive_high()
+    assert pin.state is True
+    assert seen == [True]
+    # Driving the same state again must not re-fire (_change_state no-op).
+    pin.drive_high()
+    assert seen == [True]
+    pin.drive_low()
+    assert pin.state is False
+    assert seen == [True, False]
+    pin.close()
+
+
+def test_multiio_pin_assert_states_helpers(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'input'
+    pin.clear_states()
+    pin.drive_high()
+    pin.drive_low()
+    pin.assert_states([False, True, False])
+    pin.assert_states_and_times([(0.0, False), (0.0, True), (0.0, False)])
+
+
+def test_multiio_pin_close(multiio_relay):
+    pin = multiio_relay.pin(1)
+    pin.function = 'output'
+    pin.close()
+    assert pin.function == 'input'
+
+
+# MegaindPin
+
+def test_megaind_pin_no_change_state_noop(megaind_od):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    assert pin._change_state(False) is False
+
+
+def test_megaind_pin_pull_requires_input_function(megaind_od):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    with pytest.raises(PinFixedPull):
+        pin.pull = 'up'
+
+
+def test_megaind_pin_pull(megaind_od):
+    pin = megaind_od.pin(1)
+    pin.pull = 'up'
+    assert pin.pull == 'up'
+    with pytest.raises(PinInvalidPull):
+        pin.pull = 'bogus'
+
+
+def test_megaind_pin_bounce(megaind_od):
+    pin = megaind_od.pin(1)
+    assert pin.bounce is None
+    pin.bounce = 0.1
+    assert pin.bounce == 0.1
+    with pytest.raises(PinInvalidBounce):
+        pin.bounce = 'not-a-number'
+
+
+def test_megaind_pin_edges(megaind_od):
+    pin = megaind_od.pin(1)
+    assert pin.edges == 'both'
+    pin.edges = 'rising'
+    assert pin.edges == 'rising'
+
+
+def test_megaind_pin_event_detect_are_noops(megaind_od):
+    pin = megaind_od.pin(1)
+    pin.function = 'input'
+    seen = []
+
+    def changed(ticks, state):
+        seen.append(state)
+
+    # No hardware interrupt exists for a plain digital OD input, so these
+    # are no-ops; assigning when_changed must not raise.
+    pin.when_changed = changed
+    pin.when_changed = None
+
+
+def test_megaind_pin_close(megaind_od):
+    pin = megaind_od.pin(1)
+    pin.function = 'output'
+    pin.close()
+    assert pin.function == 'input'
+
+
+# MegaindOptoPin
+
+def test_megaind_opto_pin_function_input_ok(megaind_opto):
+    pin = megaind_opto.pin(1)
+    pin.function = 'input'
+    assert pin.function == 'input'
+
+
+def test_megaind_opto_pin_no_pwm(megaind_opto):
+    pin = megaind_opto.pin(1)
+    assert pin.frequency is None
+    with pytest.raises(PinPWMUnsupported):
+        pin.frequency = 100
+
+
+def test_megaind_opto_pin_pull(megaind_opto):
+    pin = megaind_opto.pin(1)
+    assert pin.pull == 'floating'
+    pin.pull = 'up'
+    assert pin.pull == 'up'
+    with pytest.raises(PinInvalidPull):
+        pin.pull = 'bogus'
+
+
+def test_megaind_opto_pin_bounce_and_edges(megaind_opto):
+    pin = megaind_opto.pin(1)
+    assert pin.bounce is None
+    pin.bounce = 0.1
+    assert pin.bounce == 0.1
+    assert pin.edges == 'both'
+    pin.edges = 'rising'
+    assert pin.edges == 'rising'
+
+
+def test_megaind_opto_pin_enable_event_detect_twice_is_noop(megaind_opto):
+    pin = megaind_opto.pin(1)
+    pin._enable_event_detect()
+    thread = pin._poll_thread
+    pin._enable_event_detect()  # already running: must not replace the thread
+    assert pin._poll_thread is thread
+    pin._disable_event_detect()
+
+
+def test_megaind_opto_pin_disable_event_detect_without_enable_is_noop(megaind_opto):
+    pin = megaind_opto.pin(1)
+    assert pin._poll_thread is None
+    pin._disable_event_detect()  # must not raise
+    assert pin._poll_thread is None
+
+
+def test_megaind_opto_pin_edges_none_suppresses_callback(megaind_opto, megaind_mod):
+    pin = megaind_opto.pin(1)
+    pin.edges = 'none'
+    seen = []
+
+    def changed(ticks, state):
+        seen.append(state)
+
+    pin.when_changed = changed
+    megaind_mod.getOpto.return_value = 1
+    sleep(0.1)  # several poll cycles: state changes internally but never fires
+    assert seen == []
+    assert pin.state == 1
+    pin.close()
+
+
+def test_megaind_opto_pin_no_change_keeps_polling(megaind_opto, megaind_mod):
+    pin = megaind_opto.pin(1)
+    seen = []
+
+    def changed(ticks, state):
+        seen.append(state)
+
+    pin.when_changed = changed
+    # Value never changes from the fixture default (0): the poll loop should
+    # keep running (change_state() returning False each time) without firing.
+    sleep(0.1)
+    assert seen == []
+    pin.close()
+
+
+# Factories
+
+def test_multiio_factory_reset(multiio_relay):
+    multiio_relay.pin(1)
+    assert len(multiio_relay.pins) == 1
+    multiio_relay.reset()
+    assert len(multiio_relay.pins) == 0
+
+
+def test_multiio_factory_pin_explicit_class_match(multiio_relay):
+    pin1 = multiio_relay.pin(1, pin_class=MultiIOPin)
+    pin2 = multiio_relay.pin(1, pin_class=MultiIOPin)
+    assert pin1 is pin2
+
+
+def test_multiio_factory_pin_class_mismatch_raises(multiio_relay):
+    multiio_relay.pin(1)
+    with pytest.raises(ValueError):
+        multiio_relay.pin(1, pin_class=MultiIOAnalogPin)
+
+
+def test_multiio_factory_pin_invalid_name(multiio_relay):
+    with pytest.raises(PinInvalidPin):
+        multiio_relay.pin('not-a-real-pin-name')
+
+
+def test_multiio_factory_relay_and_analog_in_wrappers(multiio_mod):
+    factory = MultiIOFactory(stack=0)
+    relay = factory.relay(channel=1)
+    assert isinstance(relay, MultiIORelay)
+    analog = factory.analog_in(channel=1)
+    assert isinstance(analog, MultiIOAnalogInput)
+
+
+def test_multiio_factory_ticks(multiio_relay):
+    t1 = MultiIOFactory.ticks()
+    t2 = MultiIOFactory.ticks()
+    assert t2 >= t1
+    assert MultiIOFactory.ticks_diff(t2, t1) >= 0
+
+
+def test_megaind_factory_reset(megaind_od):
+    megaind_od.pin(1)
+    assert len(megaind_od.pins) == 1
+    megaind_od.reset()
+    assert len(megaind_od.pins) == 0
+
+
+def test_megaind_factory_pin_invalid_name(megaind_od):
+    with pytest.raises(PinInvalidPin):
+        megaind_od.pin('not-a-real-pin-name')
+
+
+def test_megaind_factory_ticks(megaind_od):
+    t1 = MegaindFactory.ticks()
+    t2 = MegaindFactory.ticks()
+    assert t2 >= t1
+    assert MegaindFactory.ticks_diff(t2, t1) >= 0
+
+
+# MultiIOAnalogInput / MultiIORelay
+
+def test_multiio_analog_input_wrapper(multiio_mod):
+    multiio_mod.get_u_in.return_value = 7.5
+    analog = MultiIOAnalogInput(stack=0, channel=1)
+    assert analog.value == 0.75
+    assert analog.volts == 7.5
+
+
+def test_multiio_relay_wrapper(multiio_mod):
+    relay = MultiIORelay(stack=0, channel=1)
+    relay.on()
+    multiio_mod.set_relay.assert_called_with(1, 1)
+    relay.off()
+    multiio_mod.set_relay.assert_called_with(1, 0)


### PR DESCRIPTION
adding support for sequent microsystems boards

https://sequentmicrosystems.com/

examples of boards:
https://sequentmicrosystems.com/products/industrial-automation-for-raspberry-pi?_pos=1&_sid=a493574da&_ss=r
https://sequentmicrosystems.com/products/multi-io-hat-8-layer-stackable-hat-for-raspberry-pi?_pos=1&_psq=multi-IO+8-layer&_ss=e&_v=1.0

thank you for your feedback 