### PR TITLE
Delegate pin factory to LEDMultiCharDisplay's plex device, close #1213

### DIFF
--- a/gpiozero/boards.py
+++ b/gpiozero/boards.py
@@ -1098,7 +1098,7 @@ class LEDMultiCharDisplay(CompositeOutputDevice):
                 pin, active_high=active_high, initial_value=None,
                 pin_factory=pin_factory)
             for pin in pins
-        ))
+        ), pin_factory=pin_factory)
         super().__init__(
             plex=plex, char=char, pin_factory=pin_factory)
         self.value = initial_value

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1632,6 +1632,17 @@ def test_led_multichar_display_init(mock_factory):
         with LEDMultiCharDisplay(char, *range(18, 22), pin_factory=mock_factory) as multichar:
             assert multichar.pin_factory is char.pin_factory
 
+def test_led_multichar_display_plex_pin_factory(mock_factory):
+    # The explicit pin_factory must reach the internal plex device too, not
+    # just its sub-devices (see #1213)
+    from gpiozero.pins.mock import MockFactory
+    other_factory = MockFactory()
+    with LEDCharDisplay(*range(10, 17), dp=17,
+                        pin_factory=other_factory) as char:
+        with LEDMultiCharDisplay(char, *range(18, 22),
+                                 pin_factory=other_factory) as multichar:
+            assert multichar.plex.pin_factory is other_factory
+
 def test_led_multichar_display_plex_delay(mock_factory):
     pins = [mock_factory.pin(i) for i in range(10, 22)]
     with LEDCharDisplay(*range(10, 17), dp=17) as char:


### PR DESCRIPTION
Close #1213

`LEDMultiCharDisplay.__init__` passed an explicit `pin_factory` to the `OutputDevice` sub-devices but not to the `CompositeOutputDevice` (`plex`) wrapping them, so the plex device always fell back to the default factory. On a machine with no real pin backend this makes constructing the display with a mock factory raise `BadPinFactory`.

Added a regression test that asserts `multichar.plex.pin_factory` is the supplied factory; it fails before the change and passes after.