### PR TITLE
Fix crash when a device with an active source is cleaned up late at shutdown

### DIFF
--- a/gpiozero/threads.py
+++ b/gpiozero/threads.py
@@ -47,11 +47,19 @@ class GPIOThread(Thread):
         self.join(timeout)
 
     def join(self, timeout=None):
-        super().join(timeout)
+        # Only call the real Thread.join() if the thread might still be
+        # running. This makes join() (and hence stop()) safe to call more
+        # than once, including late during interpreter shutdown when a
+        # device's __del__ re-runs close() after atexit's _threads_shutdown()
+        # already joined this thread; by that point calling Thread.join()
+        # again can raise TypeError as CPython tears down threading
+        # internals before running finalizers.
         if self.is_alive():
-            assert timeout is not None
-            # timeout can't be None here because if it was, then join()
-            # wouldn't return until the thread was dead
-            raise ZombieThread(f"Thread failed to die within {timeout} seconds")
-        else:
-            _THREADS.discard(self)
+            super().join(timeout)
+            if self.is_alive():
+                assert timeout is not None
+                # timeout can't be None here because if it was, then join()
+                # wouldn't return until the thread was dead
+                raise ZombieThread(
+                    f"Thread failed to die within {timeout} seconds")
+        _THREADS.discard(self)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -8,12 +8,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import gc
+import threading
+from itertools import repeat
 from time import sleep
 from threading import Event
+from unittest import mock
 
 import pytest
 
 from gpiozero import *
+from gpiozero.threads import _threads_shutdown
 
 
 def test_source_delay(mock_factory):
@@ -37,6 +41,37 @@ def test_source(mock_factory):
         # Give the output device some time to read the input device state
         sleep(0.1)
         assert out_dev.value == 1
+
+
+def test_close_after_threads_shutdown_is_safe(mock_factory):
+    # Regression test: setting .source then exiting the Python shell could
+    # raise "TypeError: 'NoneType' object is not callable" from inside
+    # __del__.
+    #
+    # gpiozero's atexit handler joins all live GPIOThreads via
+    # _threads_shutdown() *before* interpreter shutdown reaches the point
+    # where calling Thread.join() again becomes unsafe. But a device whose
+    # close() hadn't been called yet (e.g. because __del__ runs later, after
+    # atexit) still holds a reference to that now-already-joined thread. Its
+    # own close() -> source setter -> stop() -> join() must not attempt a
+    # second real join, or it can crash exactly as threading internals are
+    # torn down during shutdown.
+    device = OutputDevice(2)
+    device.source_delay = 0.01
+    device.source = repeat(0)  # a never-ending source, like sin_values()
+    sleep(0.05)  # let the source thread actually start running
+    assert device._source_thread is not None
+    assert device._source_thread.is_alive()
+
+    _threads_shutdown()  # simulates gpiozero's atexit hook running first
+    assert not device._source_thread.is_alive()
+
+    with mock.patch.object(
+            threading.Thread, 'join',
+            side_effect=TypeError("'NoneType' object is not callable")):
+        device.close()  # simulates a later __del__-triggered close()
+
+    assert device.closed
 
 
 def test_active_time(mock_factory):

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,50 @@
+# vim: set fileencoding=utf-8:
+#
+# GPIO Zero: A simple interface to GPIO devices with Raspberry Pi
+#
+# Copyright (c) 2026 Ben Nuttall <ben@bennuttall.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import threading
+from unittest import mock
+
+from gpiozero.threads import GPIOThread
+
+
+def test_join_after_already_joined_does_not_rejoin():
+    # Regression test for a crash seen when a GPIOThread is joined once (e.g.
+    # by gpiozero's atexit handler) and then joined again later (e.g. from a
+    # device's __del__-triggered close()). During interpreter shutdown a
+    # second real Thread.join() call can raise TypeError because CPython
+    # tears down threading internals before running finalizers, so join()
+    # must not attempt a second real join once the thread's already finished.
+    thread = GPIOThread(target=lambda: None)
+    thread.start()
+    thread.join(1)
+    assert not thread.is_alive()
+    with mock.patch.object(
+            threading.Thread, 'join',
+            side_effect=TypeError("'NoneType' object is not callable")):
+        thread.join(1)  # must not raise
+
+
+def test_stop_after_already_stopped_does_not_rejoin():
+    thread = GPIOThread(target=lambda: None)
+    thread.start()
+    thread.stop(1)
+    assert not thread.is_alive()
+    with mock.patch.object(
+            threading.Thread, 'join',
+            side_effect=TypeError("'NoneType' object is not callable")):
+        thread.stop(1)  # must not raise
+
+
+def test_join_still_waits_for_a_running_thread():
+    evt = threading.Event()
+    thread = GPIOThread(target=evt.wait)
+    thread.start()
+    assert thread.is_alive()
+    evt.set()
+    thread.join(1)
+    assert not thread.is_alive()


### PR DESCRIPTION
- Closes #1226

## Summary

Fixes a crash that can occur when a device with an active `.source` is cleaned up late during interpreter shutdown, e.g.:

```pycon
>>> from gpiozero import JamHat
>>> from gpiozero.tools import sin_values
>>> jam = JamHat()
>>> jam.buzzer.source = sin_values()
>>>
Exception ignored in: <function GPIOBase.__del__ at 0x7fa6d01f80>
Traceback (most recent call last):
  ...
  File ".../gpiozero/threads.py", line 49, in join
  File ".../threading.py", line 1086, in join
TypeError: 'NoneType' object is not callable
```

### Root cause

gpiozero registers an `atexit` handler (`_shutdown`) that calls `_threads_shutdown()` to proactively join every live `GPIOThread` before interpreter shutdown reaches the point where touching `threading` internals becomes unsafe.

However, `_devices_shutdown()` (the other half of that handler) only closes devices found in `Device.pin_factory._reservations`, which is keyed by raw pin reservations. Composite/wrapper devices like `JamHat`'s `TonalBuzzer` aren't in there themselves — only the inner pin device they wrap is — so `close()` is never called on them during the orderly `atexit` pass.

If such a device has an active `.source`, its `__del__`-triggered `close()` only runs later, via normal garbage collection, well after `_threads_shutdown()` already joined its background thread once. Calling `join()` on that already-finished thread a second time can raise `TypeError: 'NoneType' object is not callable`, because by then CPython has started tearing down `threading` module internals ahead of running finalizers.

### Fix

`GPIOThread.join()` now skips the real `Thread.join()` call entirely once the thread is no longer alive, making `join()`/`stop()` safe to call more than once regardless of when the second call happens — whether that's a normal double-`close()`, or this late-shutdown scenario.

## Test plan

- [x] Added `tests/test_threads.py`: unit tests on `GPIOThread` directly — confirms `join()`/`stop()` don't attempt a second real join once the thread has already finished (verified by making `threading.Thread.join` raise on a second call), and that a still-running thread is still correctly waited on.
- [x] Added a regression test in `tests/test_mixins.py` (`test_close_after_threads_shutdown_is_safe`) mirroring the actual reported scenario: set `.source`, call `_threads_shutdown()` to simulate the `atexit` hook, then call `close()` again with `Thread.join` patched to raise — must not crash.
- [x] Confirmed both new `test_threads.py` cases fail on `master` (pre-fix) and pass with the fix applied.
- [x] Full test suite passes: 389 passed, 88 skipped (expected hardware-only skips).
