### PR TITLE
Fix 2.0.1.post1/post2 LGPIOFactory auto-detection regression

### DIFF
--- a/gpiozero/pins/lgpio.py
+++ b/gpiozero/pins/lgpio.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
+
 import lgpio
 
 from . import SPI


### PR DESCRIPTION
Fixes #1229

## Summary

- restore the os import used by LGPIOFactory when detecting /dev/gpiochip4
- prevent pin-factory auto-detection from raising NameError and falling through to the incompatible RPi.GPIO backend on Raspberry Pi 5

## Verification

- deterministic stubbed-backend reproduction: main raises "NameError: name 'os' is not defined"; this branch opens mocked chip 4
- WSL2 Ubuntu 24.04 / Python 3.12, matching the CI test selection: 374 passed, 103 deselected
- Windows / Python 3.13 focused device tests: 21 passed
- Pyright no longer reports the os undefined-variable error; remaining diagnostics in this module are pre-existing lgpio-stub and override issues